### PR TITLE
Add SafeSkill security badge (87/100 — Passes with Notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![License](https://img.shields.io/badge/License-Dual%20(Apache%202.0%20%2B%20Proprietary)-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.8--3.14-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![SafeSkill 87/100](https://img.shields.io/badge/SafeSkill-87%2F100_Passes%20with%20Notes-yellow)](https://safeskill.dev/scan/zhurong2020-pyobfus)
 
 A Python code obfuscator built with AST-based transformations. **Supports Python 3.8 through 3.14**. Provides reliable name mangling, string encoding, control-flow flattening, AES-256 string encryption, and — unique to pyobfus — a reverse-mapping workflow that lets you (or your AI coding assistant) debug obfuscated stack traces without giving up the protection.
 


### PR DESCRIPTION
## ⚠️ SafeSkill Security Scan Results

| Metric | Value |
|:-------|:------|
| **Overall Score** | **87/100** (Passes with Notes) |
| Code Score | 98/100 |
| Content Score | 67/100 |
| Findings | 53 findings detected (6 high) |
| Taint Flows | 0 |
| Files Scanned | 1 |
| Scan Duration | 0.3s |

### Top Findings

- 🟠 **high**: Makes HTTP request via fetch() (`cloudflare-worker/src/index.js:302`)
- 🟠 **high**: Persona/safety hijack attempt detected (unrestricted-mode): "WITHOUT LIMIT" (`docs/legal/TERMS_OF_SERVICE.md:144`)
- 🟠 **high**: Persona/safety hijack attempt detected (unrestricted-mode): "without restriction" (`docs/legal/TERMS_OF_SERVICE.md:244`)
- 🟠 **high**: Context boundary escape detected (fake-turn-marker): "User:" (`pyobfus_mcp/README.md:104`)
- 🟠 **high**: Context boundary escape detected (fake-turn-marker): "User:" (`pyobfus_mcp/README.md:111`)

[View full report on SafeSkill](https://safeskill.dev/scan/zhurong2020-pyobfus)

---

### About SafeSkill

[SafeSkill](https://safeskill.dev) is a **free, open-source** security scanner for AI tools, MCP servers, and Claude Code skills. We scan for code exploits, prompt injection, and data exfiltration risks.

**False positive?** We take accuracy seriously. If any finding above is incorrect, please [open an issue](https://github.com/OyadotAI/safeskill/issues/new?title=False+positive+in+zhurong2020%2Fpyobfus&labels=false-positive) and we will fix it immediately.

- [GitHub](https://github.com/OyadotAI/safeskill) | [Website](https://safeskill.dev) | [Docs](https://safeskill.dev/docs)
- Built by [Oya.ai](https://oya.ai) -- AI Employees Builder
