### PR TITLE
fix(license): make LICENSE pure Apache-2.0 for SPDX detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,18 +1,3 @@
-DUAL LICENSE NOTICE
-===================
-
-This project uses a dual licensing model:
-
-1. pyobfus (Core Module) - Apache License 2.0
-   The core obfuscation engine is open source and free to use.
-   See the Apache License 2.0 text below.
-
-2. pyobfus_pro (Pro Module) - Proprietary License
-   Pro features require a paid license.
-   See pyobfus_pro/LICENSE for terms.
-
-================================================================================
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE-NOTICE.md
+++ b/LICENSE-NOTICE.md
@@ -1,0 +1,11 @@
+# Dual License Notice
+
+pyobfus uses a dual licensing model:
+
+1. **pyobfus (Core Module) — Apache License 2.0**
+   The core obfuscation engine is open source and free to use.
+   See [`LICENSE`](LICENSE) for the full Apache License 2.0 text.
+
+2. **pyobfus_pro (Pro Module) — Proprietary License**
+   Pro features require a paid license.
+   See [`pyobfus_pro/LICENSE`](pyobfus_pro/LICENSE) for terms.

--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Because obfuscated code must decrypt strings at runtime, the encryption key is n
 - **[Security Policy](https://github.com/zhurong2020/pyobfus/blob/main/SECURITY.md)** - How to report security vulnerabilities
 
 ### Legal & License
-- **Dual License Model**:
+- **Dual License Model** (see [`LICENSE-NOTICE.md`](https://github.com/zhurong2020/pyobfus/blob/main/LICENSE-NOTICE.md)):
   - **pyobfus** (Core): [Apache 2.0](https://github.com/zhurong2020/pyobfus/blob/main/LICENSE) - Free and open source
   - **pyobfus_pro** (Pro): [Proprietary](https://github.com/zhurong2020/pyobfus/blob/main/pyobfus_pro/LICENSE) - Requires paid license
 

--- a/docs/POST_V0.4_TODO.md
+++ b/docs/POST_V0.4_TODO.md
@@ -390,6 +390,7 @@ gh api repos/zhurong2020/pyobfus --jq '.topics' | tr ',' '\n' | grep -i pyarmor 
 **Done when**: classifier changed (queued for N1 bump), COMPARISON.md upgraded (✅ this session), 32768-byte cross-reference added (deferred · coordinate with other session), README/HN/landing page reflect three-layer framing (README ✅ this session; HN/landing page later).
 
 **Additional doc-lag item discovered 2026-05-09**: `README.md` line ~27 says "registers **five** MCP tools" — pyobfus-mcp 0.2.0 actually has **7** (added `recommend_tier` + `start_pro_trial` per N2). Fix the count + add the 2 new tools to the bullet table when N1 bump goes out (same trigger as N10-1 classifier change · do-not-do version-bump rule applies). awesome-mcp-servers PR #5777 description was already refreshed independently 2026-05-09 (silent edit).
+- **2026-05-29 update**: the awesome-mcp-servers **README entry line** (not just the PR description) was bumped from "Five tools" → "Seven tools" (added `recommend_tier` + `start_pro_trial`) on fork branch `add-pyobfus-mcp`. The pyobfus repo's own `README.md` line ~27 count fix **remains deferred** to the N1 bump per the do-not-do version-bump rule.
 
 ---
 
@@ -445,7 +446,8 @@ So target submission window = **2026-Q3 / Q4** (after v0.5 ships on PyPI per Pat
 
 | Item | Trigger condition | ETA |
 |---|---|---|
-| punkpeye merges PR #5777 | 86k★-repo human cadence · `state=OPEN` confirmed 2026-05-08 morning · all bot labels green (`has-emoji`/`has-glama`/`valid-name`) · 13h-old self status update referencing Glama Quality A still un-acked by maintainer | 3-7 days typical |
+| punkpeye merges PR #5777 | 86k★-repo human cadence · `state=OPEN` · all bot labels green (`has-emoji`/`has-glama`/`valid-name`). **2026-05-29: PR had gone `CONFLICTING`/`DIRTY` (README.md collided with newer merges) — resolved by merging `upstream/main` into branch + re-appending the pyobfus entry (now 7 tools); GitHub back to `MERGEABLE`.** | 3-7 days typical |
+| Glama license badge F → A | **2026-05-29: root-caused — GitHub `licensee` returned `NOASSERTION` because the dual-license preamble prefixed the Apache text; Glama mirrors that field.** Fix on branch `fix/license-spdx-detection` (PR #15): `LICENSE` now pure Apache-2.0, notice moved to `LICENSE-NOTICE.md`. Clears after PR #15 merges to `main` → GitHub re-detects Apache-2.0 → Glama cron re-crawl. | minutes (GitHub) + 1-3 days (Glama crawl) after merge |
 | Glama "No glama.json" checklist clears | Glama cron re-scan after `glama.json` schema fix (commit `8d92487`) | 1-3 days |
 | First external GitHub issue | Real user encounters something | depends on launch |
 | First Pro license sale | Launch traffic + Stripe checkout funnel | depends on launch |


### PR DESCRIPTION
## Why
Glama shows **F · license not found** for `pyobfus-mcp`. Root cause: GitHub's `licensee` reports `spdx_id: NOASSERTION` because the `LICENSE` file prefixed the Apache-2.0 text with a custom 13-line `DUAL LICENSE NOTICE` preamble, dropping the similarity match below threshold. Glama reads GitHub's field directly.

## Change
- `LICENSE` → now verbatim Apache-2.0 text (preamble stripped)
- `LICENSE-NOTICE.md` → new file holding the dual-license model (Core Apache-2.0 / Pro proprietary)
- `README.md` → License section links to `LICENSE-NOTICE.md`

No code changes. `pyproject.toml` already declares `Apache-2.0`.

## Effect
Once merged to `main`, GitHub re-detects `Apache-2.0` within minutes; Glama refreshes on its next crawl → license badge flips A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Commit 2 (docs):** also syncs `docs/POST_V0.4_TODO.md` — records this Glama "license not found" root cause as a P2 tracking row, plus the related awesome-mcp-servers PR #5777 conflict resolution (separate repo). No source changes.
