### PR TITLE
fix: Python 3.9/3.10 CI failures in --seal-code and --vault build passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--seal-code` spurious `IntegrityError` on Python 3.9/3.10.** The integrity
+  seal hashed the function's code object with `marshal.dumps` at the default
+  version (>= 3), which encodes each string's *interned* status and shares
+  object references. The build-time code object (compiled from an in-memory
+  AST) and the runtime one (compiled by the import machinery) can differ in
+  those identity-level details — on Python 3.9/3.10 they did — so a sealed
+  function's runtime hash diverged from its build-time seal and raised a false
+  `IntegrityError`, most visibly when `--seal-code` was combined with the other
+  build-fusion passes. The seal is now pinned to marshal version 2, which
+  serializes by value only. No behavior change on 3.11+. Regression guard:
+  `tests/test_seal_runtime.py::TestMarshalVersionStability` plus the existing
+  end-to-end `test_build_fusion` suite running on the full 3.9–3.14 CI matrix.
+
 ## [0.5.1] - 2026-06-22
 
 **Build-fusion release.** (Built 2026-06-18; published to PyPI 2026-06-22 via OIDC Trusted Publishing with PEP 740 attestations.) The v0.5 Pro mechanisms are now wired into the main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   serializes by value only. No behavior change on 3.11+. Regression guard:
   `tests/test_seal_runtime.py::TestMarshalVersionStability` plus the existing
   end-to-end `test_build_fusion` suite running on the full 3.9–3.14 CI matrix.
+- **`--vault` `TypeError: zip() takes no keyword arguments` on Python 3.9.** The
+  vault build transformer used `zip(..., strict=True)`, but the `strict`
+  keyword was only added to `zip()` in Python 3.10, so every vault-dependent
+  path (the vault transformer, the combined build-fusion passes, device
+  binding, and the six-feature integration round-trip) raised on 3.9 — a
+  supported floor. Dropped to a plain `zip()`; the `strict` check was redundant
+  because an `ast.Dict` always has equal-length `keys`/`values` and the only
+  exception (`**`-unpacking) is already rejected upstream.
 
 ## [0.5.1] - 2026-06-22
 

--- a/pyobfus_pro/runtime/seal.py
+++ b/pyobfus_pro/runtime/seal.py
@@ -96,7 +96,16 @@ def _hash_code(code: types.CodeType) -> bytes:
         # shape stays stable across Python versions.
         getattr(code, "co_exceptiontable", b""),
     )
-    return hashlib.sha256(marshal.dumps(behavioral)).digest()
+    # marshal version 2 (pre-FLAG_REF) is REQUIRED, not incidental: the default
+    # version (>=3) encodes each string's *interned* status (TYPE_SHORT_ASCII vs
+    # TYPE_SHORT_ASCII_INTERNED) and shares object references. The interned-state
+    # of identifier strings in co_names/co_varnames can legitimately differ
+    # between the build-time code object (compiled from an in-memory AST) and the
+    # runtime one (compiled by the import machinery) -- on Python 3.9/3.10 it
+    # does -- which made the seal hash diverge and raised a spurious
+    # IntegrityError. Version 2 serializes by value only (no interned distinction,
+    # no ref table), so build and runtime agree on every supported Python.
+    return hashlib.sha256(marshal.dumps(behavioral, 2)).digest()
 
 
 def _compute_seal(func_or_code: Any) -> bytes:

--- a/pyobfus_pro/transformers/vault.py
+++ b/pyobfus_pro/transformers/vault.py
@@ -270,7 +270,12 @@ def _validate_literal_str_dict(vault_name: str, node: ast.Dict) -> dict[str, str
             f"vault_secrets({vault_name!r}) does not support **-unpacking " f"in the dict literal"
         )
     out: dict[str, str] = {}
-    for key_node, value_node in zip(node.keys, node.values, strict=True):
+    # Plain zip (no strict=): the kwarg was added in Python 3.10 and raises
+    # TypeError on 3.9 (a supported floor). It is also unnecessary here -- an
+    # ``ast.Dict`` always has ``len(keys) == len(values)``, and the only case
+    # that breaks that invariant (``**``-unpacking, which yields a None key) is
+    # already rejected by the guard above.
+    for key_node, value_node in zip(node.keys, node.values):
         if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
             raise VaultBuildError(
                 f"vault_secrets({vault_name!r}) entry key must be a string "

--- a/tests/test_seal_runtime.py
+++ b/tests/test_seal_runtime.py
@@ -197,3 +197,59 @@ class TestMarshalBasedHashing:
         assert f.__code__.co_code == g.__code__.co_code
         # But the marshal-based seals differ:
         assert _compute_seal(f) != _compute_seal(g)
+
+
+class TestMarshalVersionStability:
+    """Regression: the seal hash must be pinned to marshal version 2.
+
+    The default marshal version (>= 3) is FORBIDDEN here. It encodes each
+    string's *interned* status (TYPE_SHORT_ASCII vs TYPE_SHORT_ASCII_INTERNED)
+    and shares object references (FLAG_REF). The build-time code object
+    (compiled from an in-memory AST) and the runtime code object (compiled by
+    the import machinery) can legitimately differ in those identity-level
+    details -- on Python 3.9/3.10 they did -- which made a sealed function's
+    build hash diverge from its runtime hash and raised a SPURIOUS
+    ``IntegrityError`` whenever ``--seal-code`` was combined with the other
+    build-fusion passes. Version 2 serializes by value only, so build and
+    runtime agree on every supported Python.
+
+    See ``pyobfus_pro/runtime/seal.py::_hash_code`` and the end-to-end guard
+    ``tests/test_build_fusion.py::TestFusionRuntime::test_combined_runs_correctly``
+    (which exercises the real build -> import -> verify path on the full
+    3.9-3.14 CI matrix).
+    """
+
+    def _behavioral_hash(self, code, version):
+        import hashlib
+        import marshal
+        import types
+
+        consts = tuple(
+            _compute_seal(c) if isinstance(c, types.CodeType) else c for c in code.co_consts
+        )
+        behavioral = (
+            code.co_code,
+            consts,
+            code.co_names,
+            code.co_varnames,
+            code.co_freevars,
+            code.co_cellvars,
+            code.co_flags,
+            code.co_argcount,
+            code.co_posonlyargcount,
+            code.co_kwonlyargcount,
+            code.co_stacksize,
+            getattr(code, "co_exceptiontable", b""),
+        )
+        return hashlib.sha256(marshal.dumps(behavioral, version)).digest()
+
+    def test_hash_uses_marshal_version_2(self):
+        def target(value):
+            return helper(value) - 1  # noqa: F821 -- only the code object matters
+
+        code = target.__code__
+        # The seal must equal the version-2 projection ...
+        assert _compute_seal(target) == self._behavioral_hash(code, 2)
+        # ... and must NOT silently fall back to a >=3 (interning/ref-sharing)
+        # encoding, which is what reintroduced the 3.9/3.10 divergence.
+        assert _compute_seal(target) != self._behavioral_hash(code, 4)


### PR DESCRIPTION
Fixes the CI failures on **Python 3.9 and 3.10** (3.11–3.14 were already green). Two independent, version-specific bugs in the v0.5.1 build-fusion Pro passes.

## Fix 1 — `--seal-code` spurious `IntegrityError` on 3.9/3.10

`pyobfus_pro/runtime/seal.py::_hash_code` serialized the code object with `marshal.dumps(behavioral)` at the **default marshal version (≥3)**, which encodes each string's *interned* status (`TYPE_SHORT_ASCII` vs `TYPE_SHORT_ASCII_INTERNED`) and shares object references (`FLAG_REF`). The build-time code object (compiled from an in-memory AST) and the runtime one (compiled by the import machinery) can differ in those identity-level details — on 3.9/3.10 they did — so a sealed function's runtime hash diverged from its baked build-time seal → false `IntegrityError`. Most visible when `--seal-code` combined with the other build-fusion passes.

**Fix:** pin the seal serialization to **marshal version 2** (pre-`FLAG_REF`, value-only). No behavior change on 3.11+; the seal still covers `co_code`, `co_consts`, and every other behavioral field.

**Regression guard:** `tests/test_seal_runtime.py::TestMarshalVersionStability` (white-box pin) + the existing end-to-end `test_build_fusion` suite on the full matrix.

## Fix 2 — `--vault` `TypeError: zip() takes no keyword arguments` on 3.9

`pyobfus_pro/transformers/vault.py` used `zip(..., strict=True)`, but the `strict` kwarg was only added to `zip()` in Python 3.10. On 3.9 every vault-dependent path raised at build time (vault transformer, build-fusion, device binding, license-binding vault integration, six-feature integration round-trip — the bulk of the remaining 3.9 failures).

**Fix:** plain `zip()`. The `strict` check was redundant — an `ast.Dict` always has equal-length `keys`/`values`, and the only exception (`**`-unpacking → `None` key) is already rejected upstream.

## Verification

- **CI matrix:** all green, including **3.9 and 3.10** (previously failing), plus 3.11–3.14, Lint, Integration, MCP-SDK-latest, CodeQL.
- **Local:** core suite **1025 passed / 1 skipped** on 3.10 & 3.12; `pyobfus_mcp` **73 passed**; vault/integration/build-fusion/license-binding **70 passed** each; black + ruff clean.

Scoped to 4 files (`seal.py`, `vault.py`, `test_seal_runtime.py`, `CHANGELOG.md`). Targets a **0.5.2** patch — both bugs are present in the published 0.5.1 wheel and break `--seal-code`/`--vault` for users on Python 3.9/3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)