### PR TITLE
feat(pro): device-bind String Vault keys under --bind-device (0.5.4)

### DIFF
--- a/pyobfus/cli.py
+++ b/pyobfus/cli.py
@@ -217,8 +217,9 @@ except ImportError:
 @click.option(
     "--bind-device",
     is_flag=True,
-    help="Bind L3 encryption to this build machine; decrypts only on it "
-    "(Pro, v0.5.3; needs --selective-opacity/--opacity-config; distinct from --bind-machine)",
+    help="Bind L3 opacity and/or --vault keys to this build machine; decrypts "
+    "only on it (Pro, v0.5.3; pairs with --selective-opacity/--opacity-config "
+    "and/or --vault; distinct from --bind-machine)",
 )
 @click.option(
     "--bind-device-id",

--- a/pyobfus_pro/build_fusion.py
+++ b/pyobfus_pro/build_fusion.py
@@ -26,6 +26,13 @@ and ``--bind-device`` (encrypts the L3 layer key with a device fingerprint at
 build, then rewrites the emitted ``_LAYER_KEY`` literal into a runtime
 ``bind_device_key(current_machine_id(), salt)`` re-derivation, so decryption only
 succeeds on the bound device — supplied ``--bind-device-id`` or the build machine).
+
+0.5.4 extends ``--bind-device`` to the String Vault: with ``--vault`` set, each
+vault's ``_VAULT_KEY_<name>`` is likewise encrypted with a per-vault
+device-derived key at build and rewritten into a runtime re-derivation, so vault
+keys no longer ship as at-rest literals either. This runs in the vault PRE-pass
+(see :func:`_apply_vault_device_binding`) because Core preserves the
+``_VAULT_KEY_<name>`` constant names and imported symbols through mangling.
 """
 
 from __future__ import annotations
@@ -150,6 +157,130 @@ def _substitute_layer_key_binding(source: str, salt: bytes) -> str:
     return ast.unparse(tree)
 
 
+_VAULT_KEY_PREFIX = "_VAULT_KEY_"
+
+
+def _apply_vault_device_binding(source: str, config) -> str:
+    """Run the vault PRE-pass with per-vault **device-derived** keys and rewrite
+    each emitted ``_VAULT_KEY_<name>`` literal into a runtime re-derivation.
+
+    Mirrors opacity's ``--bind-device`` handling for the *constant*
+    materialization channel: each vault gets a fresh 32-byte salt, its blob is
+    encrypted at build with ``bind_device_key(target_id, salt)`` (``target_id``
+    = ``--bind-device-id`` or the build machine), and the baked
+    ``_VAULT_KEY_<name> = b"..."`` is replaced with
+    ``_VAULT_KEY_<name> = bind_device_key(current_machine_id(), _pyobfus_vault_salt_<name>)``
+    so the raw key never ships and each vault decrypts only on the bound device.
+
+    Per-vault salts (not one shared salt) keep the vault keys mutually
+    independent, preserving the transformer's per-vault-key design under device
+    binding. No-op device binding when the module has no vaults.
+    """
+    import secrets
+
+    from .license_binding import bind_device_key, current_machine_id
+
+    names = _t_vault.collect_vault_names(source)
+    if not names:
+        # --bind-device --vault on a module with no vault_secrets({...}): the
+        # plain transform is a no-op too, but call it for parity / import shape.
+        transformed, _schemas = _t_vault.transform_module(source)
+        return transformed
+
+    salts = {name: secrets.token_bytes(_BUILD_SALT_SIZE) for name in names}
+    target_id = getattr(config, "bind_device_id", None) or current_machine_id()
+    vault_keys = {name: bind_device_key(target_id, salts[name]) for name in names}
+    transformed, _schemas = _t_vault.transform_module(source, vault_keys=vault_keys)
+    return _substitute_vault_key_bindings(transformed, salts)
+
+
+def _vault_key_target_name(node: ast.stmt) -> Optional[str]:
+    """Return ``<name>`` for a ``_VAULT_KEY_<name> = ...`` assignment, else None."""
+    if (
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id.startswith(_VAULT_KEY_PREFIX)
+    ):
+        return node.targets[0].id[len(_VAULT_KEY_PREFIX) :]
+    return None
+
+
+def _substitute_vault_key_bindings(source: str, salts: dict) -> str:
+    """Rewrite each ``_VAULT_KEY_<name> = b"..."`` into a device re-derivation.
+
+    For every vault named in ``salts`` the baked key literal becomes
+    ``bind_device_key(current_machine_id(), _pyobfus_vault_salt_<name>)`` and a
+    ``_pyobfus_vault_salt_<name> = b"..."`` assignment is inserted immediately
+    before it. A single import of the two runtime helpers is prepended once
+    (after any ``from __future__`` imports). No-op if no matching key literal is
+    present.
+    """
+    tree = ast.parse(source)
+    new_body: list[ast.stmt] = []
+    injected = False
+    for node in tree.body:
+        vault_name = _vault_key_target_name(node)
+        if vault_name is not None and vault_name in salts:
+            salt_name = f"_pyobfus_vault_salt_{vault_name}"
+            new_body.append(
+                ast.Assign(
+                    targets=[ast.Name(id=salt_name, ctx=ast.Store())],
+                    value=ast.Constant(value=salts[vault_name]),
+                )
+            )
+            node.value = ast.Call(  # type: ignore[attr-defined]
+                func=ast.Name(id="_pyobfus_bind_device_key", ctx=ast.Load()),
+                args=[
+                    ast.Call(
+                        func=ast.Name(id="_pyobfus_machine_id", ctx=ast.Load()),
+                        args=[],
+                        keywords=[],
+                    ),
+                    ast.Name(id=salt_name, ctx=ast.Load()),
+                ],
+                keywords=[],
+            )
+            injected = True
+        new_body.append(node)
+
+    if not injected:
+        return source
+
+    tree.body = new_body
+    _ensure_bind_device_import(tree)
+    ast.fix_missing_locations(tree)
+    return ast.unparse(tree)
+
+
+def _ensure_bind_device_import(tree: ast.Module) -> None:
+    """Prepend ``from pyobfus_pro import bind_device_key as _pyobfus_bind_device_key,
+    current_machine_id as _pyobfus_machine_id`` once, after any ``from __future__``
+    imports. Idempotent on the aliased names."""
+    have = set()
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                have.add(alias.asname or alias.name)
+    if {"_pyobfus_bind_device_key", "_pyobfus_machine_id"} <= have:
+        return
+    imp = ast.ImportFrom(
+        module="pyobfus_pro",
+        names=[
+            ast.alias(name="bind_device_key", asname="_pyobfus_bind_device_key"),
+            ast.alias(name="current_machine_id", asname="_pyobfus_machine_id"),
+        ],
+        level=0,
+    )
+    insert_at = 0
+    for i, node in enumerate(tree.body):
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            insert_at = i + 1
+        else:
+            break
+    tree.body.insert(insert_at, imp)
+
+
 def apply_pre_passes(source: str, config, *, module_qualname: str = "") -> str:
     """Source transforms that must run BEFORE the Core pipeline.
 
@@ -164,9 +295,20 @@ def apply_pre_passes(source: str, config, *, module_qualname: str = "") -> str:
       the injected decorator survives mangling and is consumed by the opacity
       POST-pass exactly like a hand-written one. This sidesteps any
       mangled->original name-map coupling.
+
+    When ``--bind-device`` is set the vault pass encrypts each vault with a
+    device-derived key and rewrites its emitted ``_VAULT_KEY_<name>`` literal
+    into a runtime re-derivation (see :func:`_apply_vault_device_binding`), so
+    the vault keys never ship as at-rest constants. The rewrite is done here in
+    the PRE-pass rather than the POST-pass because Core preserves both the
+    ``_VAULT_KEY_<name>`` constant names and imported symbols unchanged, so the
+    injected ``bind_device_key(...)`` derivation survives mangling intact.
     """
     if getattr(config, "vault", False):
-        source, _schemas = _t_vault.transform_module(source)
+        if getattr(config, "bind_device", False):
+            source = _apply_vault_device_binding(source, config)
+        else:
+            source, _schemas = _t_vault.transform_module(source)
     if getattr(config, "opacity_config", None):
         source = _apply_opacity_config_prepass(source, config, module_qualname)
     return source

--- a/pyobfus_pro/runtime/vault.py
+++ b/pyobfus_pro/runtime/vault.py
@@ -202,10 +202,11 @@ def vault_secrets(plaintext_entries: Mapping[str, str]) -> Vault:
         SECRETS = Vault(_VAULT_BLOB_SECRETS, _VAULT_KEY_SECRETS)
 
     The build-baked key persists across process restarts so the same
-    obfuscated artifact decrypts the same secrets every run. (Future P2-8
-    ``--bind-device`` integration will replace the baked key with a
-    runtime-derived fingerprint key, eliminating the at-rest key constant
-    entirely.)
+    obfuscated artifact decrypts the same secrets every run. With P2-8
+    ``--bind-device`` (0.5.4) the baked ``_VAULT_KEY_<name>`` literal is
+    replaced with a runtime ``bind_device_key(current_machine_id(), salt)``
+    re-derivation, eliminating the at-rest key constant entirely so the vault
+    decrypts only on the bound device.
 
     Patent-relevant: this is the analogue of P2-1's ``@opacity("encrypted")``
     decorator for the *constant* materialization channel rather than the

--- a/pyobfus_pro/transformers/vault.py
+++ b/pyobfus_pro/transformers/vault.py
@@ -198,6 +198,27 @@ def transform_module(
 # ---------------------------------------------------------------------------
 
 
+def collect_vault_names(source_code: str, *, filename: str = "<vault-pass>") -> list[str]:
+    """Return the vault attribute names in ``source_code``, in source order,
+    without encrypting anything.
+
+    Used by ``--bind-device`` to pre-derive a per-vault device key *before*
+    calling :func:`transform_module` with an explicit ``vault_keys`` mapping,
+    so the build can encrypt each vault with a device-bound key while the
+    emitted ``_VAULT_KEY_<name>`` literal is later rewritten into a runtime
+    re-derivation. Applies the same validation as the transform pass, so a
+    malformed ``vault_secrets({...})`` raises here exactly as it would there.
+
+    Raises:
+        VaultBuildError: on non-literal dict, non-string entries, or duplicate
+            vault names.
+        SyntaxError: when ``source_code`` is not valid Python.
+    """
+    tree = ast.parse(source_code, filename)
+    targets = _collect_vault_assignments(tree)
+    return [vault_name for vault_name, _plaintext in targets.values()]
+
+
 def _is_vault_secrets_call(node: ast.expr) -> bool:
     """Match ``vault_secrets(...)`` (bare) or ``<...>.vault_secrets(...)``."""
     if not isinstance(node, ast.Call):
@@ -328,4 +349,4 @@ def _ensure_vault_class_import(tree: ast.Module) -> None:
     tree.body.insert(insert_at, new_import)
 
 
-__all__: Iterable[str] = ("VaultBuildError", "transform_module")
+__all__: Iterable[str] = ("VaultBuildError", "collect_vault_names", "transform_module")

--- a/tests/test_build_fusion.py
+++ b/tests/test_build_fusion.py
@@ -353,6 +353,136 @@ class TestBindDevice:
 
 
 @requires_pro
+class TestVaultBindDevice:
+    """`--bind-device --vault` rewrites each baked `_VAULT_KEY_<name>` into a
+    runtime device-derived key, so vault decryption only succeeds on the bound
+    device. Per-vault salts keep the vault keys mutually independent."""
+
+    def _src(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text(
+            'CFG = vault_secrets({"API_KEY": "sk-secret-xyz", "ENV": "prod"})\n'
+            'DB = vault_secrets({"DSN": "postgres://secret"})\n\n'
+            "def run():\n"
+            "    return CFG.get('API_KEY') + '|' + DB.get('DSN')\n"
+        )
+        return f
+
+    def _yaml(self, tmp_path):
+        y = tmp_path / "pyobfus.yaml"
+        y.write_text("obfuscation:\n  exclude_names: [run]\n")
+        return y
+
+    def test_bind_device_rewrites_vault_keys(self, runner, tmp_path):
+        src = self._src(tmp_path)
+        out = tmp_path / "o.py"
+        res = _invoke(runner, src, out, "--vault", "--bind-device")
+        assert res.exit_code == 0, res.output
+        text = out.read_text()
+        assert "_pyobfus_bind_device_key(" in text
+        # both vaults' raw key literals must be gone
+        assert "_VAULT_KEY_CFG = b'" not in text and '_VAULT_KEY_CFG = b"' not in text
+        assert "_VAULT_KEY_DB = b'" not in text and '_VAULT_KEY_DB = b"' not in text
+        assert _compiles(out)
+
+    def test_bind_device_runs_on_build_machine(self, runner, tmp_path):
+        src = self._src(tmp_path)
+        yaml_cfg = self._yaml(tmp_path)
+        out = tmp_path / "o.py"
+        with patch("pyobfus.cli.is_trial_active", return_value=True):
+            res = runner.invoke(
+                main,
+                [
+                    str(src),
+                    "-o",
+                    str(out),
+                    "--level",
+                    "pro",
+                    "--config",
+                    str(yaml_cfg),
+                    "--vault",
+                    "--bind-device",
+                ],
+            )
+        assert res.exit_code == 0, res.output
+        m = _load_module(out, "vbd_match")
+        # build machine == run machine -> both vaults re-derive their key -> decrypt
+        assert m.run() == "sk-secret-xyz|postgres://secret"
+
+    def test_bind_device_wrong_device_fails(self, runner, tmp_path):
+        src = self._src(tmp_path)
+        yaml_cfg = self._yaml(tmp_path)
+        out = tmp_path / "o.py"
+        with patch("pyobfus.cli.is_trial_active", return_value=True):
+            res = runner.invoke(
+                main,
+                [
+                    str(src),
+                    "-o",
+                    str(out),
+                    "--level",
+                    "pro",
+                    "--config",
+                    str(yaml_cfg),
+                    "--vault",
+                    "--bind-device-id",
+                    "not-this-machine-xyz",
+                ],
+            )
+        assert res.exit_code == 0, res.output
+        m = _load_module(out, "vbd_mismatch")
+        from pyobfus_pro.runtime.vault import VaultError
+
+        # ciphertext keyed to a different device -> GCM tag fails on decrypt
+        with pytest.raises(VaultError):
+            m.run()
+
+    def test_bind_device_no_vault_secrets_is_noop(self, runner, tmp_path):
+        # --vault --bind-device on a module with no vault_secrets({...}) must
+        # not crash and must not emit a device-binding import.
+        src = tmp_path / "mod.py"
+        src.write_text("VALUE = 41\n\ndef run():\n    return VALUE + 1\n")
+        out = tmp_path / "o.py"
+        res = _invoke(runner, src, out, "--vault", "--bind-device")
+        assert res.exit_code == 0, res.output
+        assert _compiles(out)
+        assert "_pyobfus_bind_device_key(" not in out.read_text()
+
+
+@requires_pro
+def test_vault_device_binding_uses_distinct_per_vault_salts():
+    """Each vault gets its own salt (checked pre-Core so names are unmangled),
+    so the two device-derived keys are independent."""
+    import ast
+
+    from pyobfus_pro import build_fusion
+
+    class _Cfg:
+        vault = True
+        bind_device = True
+        bind_device_id = "device-under-test"
+        opacity_config = None
+
+    src = 'CFG = vault_secrets({"A": "x"})\n' 'DB = vault_secrets({"B": "y"})\n'
+    out = build_fusion._apply_vault_device_binding(src, _Cfg())
+    assert "_pyobfus_bind_device_key(" in out
+    salts = [
+        node.value.value
+        for node in ast.walk(ast.parse(out))
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id.startswith("_pyobfus_vault_salt_")
+        and isinstance(node.value, ast.Constant)
+    ]
+    assert len(salts) == 2
+    assert salts[0] != salts[1]
+    # raw key literals replaced, not baked
+    assert "_VAULT_KEY_CFG = b'" not in out
+    assert "_VAULT_KEY_DB = b'" not in out
+
+
+@requires_pro
 def test_period_runtime_enforces_limit(runner, tmp_path, monkeypatch):
     """The injected run-counter raises LicenseExpired past the limit, and the
     counter path is resolved at runtime via $PYOBFUS_COUNTER_DIR (not baked in

--- a/tests/test_vault_transformer.py
+++ b/tests/test_vault_transformer.py
@@ -194,6 +194,36 @@ class TestRoundTrip:
             transform_module(src, vault_keys={"SECRETS": b"short"})
 
 
+class TestCollectVaultNames:
+    """``collect_vault_names`` lists vault names without encrypting -- the
+    entry point ``--bind-device`` uses to pre-derive per-vault device keys."""
+
+    def test_returns_names_in_source_order(self):
+        from pyobfus_pro.transformers.vault import collect_vault_names
+
+        src = _src("""
+            from pyobfus_pro import vault_secrets
+            ALPHA = vault_secrets({"K1": "v1"})
+            BETA = vault_secrets({"K2": "v2"})
+        """)
+        assert collect_vault_names(src) == ["ALPHA", "BETA"]
+
+    def test_empty_when_no_vaults(self):
+        from pyobfus_pro.transformers.vault import collect_vault_names
+
+        assert collect_vault_names("X = 1\n") == []
+
+    def test_validates_like_transform(self):
+        from pyobfus_pro.transformers.vault import collect_vault_names
+
+        src = _src("""
+            from pyobfus_pro import vault_secrets
+            BAD = vault_secrets({"K": 123})
+        """)
+        with pytest.raises(VaultBuildError):
+            collect_vault_names(src)
+
+
 # ---------------------------------------------------------------------------
 # Multiple vaults in one module
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends `--bind-device` (P2-8) from opacity's L3 `_LAYER_KEY` to the **String Vault**'s per-vault `_VAULT_KEY_<name>` — the 0.5.4 headline (`docs/POST_V0.4_TODO.md` Part 3, task 1).

Before this change, `--vault --bind-device` derived a device key but never used it: vault keys shipped as baked at-rest literals. Now, with `--vault --bind-device` set, each vault is encrypted at build with a per-vault device-derived key `bind_device_key(target_id, salt)` (`target_id` = `--bind-device-id` or the build machine), and its emitted `_VAULT_KEY_<name> = b"..."` literal is rewritten into a runtime `bind_device_key(current_machine_id(), _pyobfus_vault_salt_<name>)` re-derivation. The raw key never ships, so the vault decrypts **only on the bound device**.

## Design

- Done in the vault **PRE-pass**, self-contained (no cross-pass state). Verified empirically that Core preserves the `_VAULT_KEY_<name>` constant names and imported symbols through name-mangling, so the injected `bind_device_key(...)` derivation survives intact.
- **Per-vault salts** (not one shared salt) keep the vault keys mutually independent, preserving the transformer's per-vault-key design under device binding.
- **No-op** when a `--vault` module has no `vault_secrets({...})`.
- **Plain `--vault`** (no `--bind-device`) is unchanged — still ships the baked literal.

## Changes

- `pyobfus_pro/build_fusion.py`: `_apply_vault_device_binding`, `_substitute_vault_key_bindings`, `_ensure_bind_device_import`; route the vault PRE-pass through device binding when `--bind-device` is set.
- `pyobfus_pro/transformers/vault.py`: `collect_vault_names` (list vault names without encrypting — lets the PRE-pass pre-derive per-vault keys before calling `transform_module(vault_keys=...)`).
- `pyobfus/cli.py`: `--bind-device` help now names `--vault` as a target.
- Docstring updates in `build_fusion.py` and `runtime/vault.py` (the runtime docstring already anticipated this exact feature).

## Tests

8 new tests: device-match runs correctly, device-mismatch raises `VaultError` on `.get()`, `--vault --bind-device` no-vault no-op, distinct per-vault salts, and `collect_vault_names` (order / empty / validation). **1041 passed, 1 skipped, 90% coverage** (`pytest tests/`). `black` / `ruff` clean; `mypy` introduces no new errors (baseline 8, unchanged).

## Notes for reviewer

- Scope boundary lifted: previously "only opacity L3 is device-locked; vault keys ship as baked literals" — that boundary is now closed.
- The vault-key device binding is patent-relevant (P2-8 × P2-11 combination); the mechanism mirrors the opacity `_LAYER_KEY` rewrite already shipped in 0.5.3 (`62646b6`).
- No version bump in this PR — 0.5.4 release packaging is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)