### PR TITLE
ci: harden quality gates and prepare post-0.5.4 launch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,19 +62,21 @@ jobs:
 
     - name: Check code formatting with black
       run: |
-        black --check pyobfus/ pyobfus_pro/ pyobfus_mcp/pyobfus_mcp/ tests/ integration_tests/
+        black --check pyobfus/ pyobfus_pro/ pyobfus_mcp/pyobfus_mcp/ tests/ integration_tests/ benchmarks/llm_resistance/
 
     - name: Lint with ruff
       run: |
-        ruff check pyobfus/ pyobfus_pro/ pyobfus_mcp/pyobfus_mcp/ tests/ integration_tests/
+        ruff check pyobfus/ pyobfus_pro/ pyobfus_mcp/pyobfus_mcp/ tests/ integration_tests/ benchmarks/llm_resistance/
 
     - name: Type check with mypy
       run: |
-        mypy pyobfus/ --ignore-missing-imports
-      # Baseline as of 2026-07-19: 8 errors across 8 files, tracked in #22.
-      # Removing continue-on-error is the last step of that issue; do not
-      # remove it until the baseline is at zero, or CI goes permanently red.
-      continue-on-error: true
+        # Check every shipped source package explicitly. Tests remain covered by
+        # runtime pytest and lint; they are not part of the public typed surface.
+        mypy pyobfus/ pyobfus_pro/ pyobfus_mcp/pyobfus_mcp/
+
+    - name: Validate discovery metadata
+      run: |
+        python -m json.tool docs/.well-known/ai-catalog.json > /dev/null
 
   mcp-tests:
     # The MCP package has its own pytest root (AGENTS.md documents three roots).
@@ -127,6 +129,31 @@ jobs:
     - name: Run end-to-end test suite
       run: |
         pytest integration_tests/ -v --no-cov
+
+  benchmark-smoke:
+    # Offline, deterministic validation of the P2-18 corpus -> obfuscate ->
+    # recover -> functional-score -> report pipeline. Real model measurements
+    # remain credentialed/manual; stub output is never published as evidence.
+    name: LLM resistance benchmark smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 (pinned 2026-05-09 for Socket supply-chain score)
+
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5 (pinned 2026-05-09)
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run offline benchmark smoke suite
+      run: |
+        pytest benchmarks/llm_resistance/test_smoke.py -v --no-cov
 
   mcp-sdk-latest:
     # Catches mcp SDK API drift against pyobfus-mcp (e.g. the FastMCP version=

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Add an additional layer of protection for commercial Python software.
 - **Python Support**: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
 - **Naming Scheme**: Index-based (I0, I1, I2...) - simple and effective
 - **Architecture**: Modular transformer pipeline with two-phase cross-file obfuscation
-- **Testing**: 1033 tests, 90% coverage, multi-OS CI/CD (Python 3.9-3.14 × Ubuntu / macOS / Windows)
+- **Testing**: 1,000+ tests, 90% coverage, multi-OS CI/CD (Python 3.9-3.14 × Ubuntu / macOS / Windows)
 
 ## Frequently Asked Questions
 
@@ -580,7 +580,11 @@ pyobfus src/ -o dist/ --dry-run
 
 ### Will my code still work after obfuscation?
 
-Yes, pyobfus guarantees **100% functional equivalence**. The obfuscated code produces identical outputs to your original code. We use Python's AST (Abstract Syntax Tree) for syntax-aware transformations, ensuring syntactically correct output.
+pyobfus is designed to preserve program behavior for supported Python syntax and
+framework patterns, and its compatibility matrix is covered by automated tests.
+Obfuscation is still a source transformation: run your own test suite and verify
+the built artifact, especially when the project relies on dynamic imports,
+reflection, or generated code.
 
 ### Does obfuscated code run slower?
 
@@ -606,7 +610,9 @@ pyobfus src/ -o dist/ -c pyobfus.yaml
 
 ### What Python versions are supported?
 
-pyobfus supports **Python 3.9 through 3.14**. Generated code is compatible with all these versions regardless of which version you use to run pyobfus.
+pyobfus supports **Python 3.9 through 3.14**. Build and test the obfuscated
+artifact with the Python version used in production; cross-interpreter
+portability can depend on syntax, dependencies, and enabled transformations.
 
 ### PyArmor vs pyobfus: Which should I choose?
 
@@ -635,7 +641,11 @@ Yes — and for many projects this is the most cost-effective approach. Use pyob
 
 ### Can obfuscated code be reversed?
 
-Name mangling is **irreversible** - original variable names cannot be recovered. However, code logic remains intact (this is true for all obfuscators). For stronger protection, use Pro features:
+Name mangling removes the original identifiers from the emitted source and
+raises the cost of analysis, but it is not cryptographically irreversible: a
+determined analyst may infer names and behavior from context. Keep the optional
+mapping file private when you need reliable reverse mapping. For stronger
+protection, use Pro features:
 - **AES-256 encryption** for strings
 - **Anti-debugging** checks to prevent analysis
 

--- a/_drafts/launch-v0.5.4/README.md
+++ b/_drafts/launch-v0.5.4/README.md
@@ -1,0 +1,49 @@
+# pyobfus 0.5.4 launch wave
+
+**Prepared**: 2026-07-20
+
+**Canonical release**: pyobfus 0.5.4 / pyobfus-mcp 0.3.1
+
+**Repository**: <https://github.com/zhurong2020/pyobfus>
+
+This folder supersedes the pre-0.5 launch drafts. It uses the real CLI syntax,
+the 0.5.4 trust boundary, and current community posting rules.
+
+## Baseline before publication
+
+- GitHub: 1 star, 2 forks, 1 open issue, 0 open pull requests.
+- PyPI pyobfus: approximately 1,174 downloads in the prior month on
+  2026-07-20. Treat this as directional because automated installs are mixed
+  into the count.
+- Release CI: 1046 passed, 1 skipped, 90% core coverage; Core, MCP, and
+  end-to-end test roots all green.
+- Public writing: one older DEV article; no completed Show HN or Reddit launch.
+
+Capture the same fields at +24 hours, +7 days, and +30 days. The decision
+metric is not raw downloads alone: count stars, forks, issues, discussion
+votes, named third-party uses, and repeated feature requests.
+
+## Sequence
+
+1. Publish `devto.md` as the canonical long-form explanation.
+2. If the maintainer's HN account satisfies the current participation gate,
+   submit `show-hn.md` on a weekday and remain available for the first 90
+   minutes. Otherwise participate normally before attempting a Show HN.
+3. Add `reddit-python.md` to the current r/Python monthly showcase thread;
+   current rules do not support the old standalone-showcase plan.
+4. Publish `cn.md` to the maintainer-controlled Chinese channel, then adapt its
+   short block for V2EX only if current forum rules permit project promotion.
+5. Open `github-poll.md` as a GitHub Discussions poll after traffic begins.
+
+Never ask friends to upvote, coordinate engagement, or cross-post the same text
+simultaneously. Each channel should invite criticism of the threat model and
+specific reports of what users need next.
+
+## External prerequisites
+
+- DEV: API key or interactive login.
+- HN: an established account currently eligible to submit Show HN.
+- Reddit: interactive login and the current monthly showcase thread.
+- GitHub Discussions: interactive GitHub login or a refreshed `gh` token.
+
+No credential is stored in this repository.

--- a/_drafts/launch-v0.5.4/cn.md
+++ b/_drafts/launch-v0.5.4/cn.md
@@ -1,0 +1,72 @@
+# 中文发布稿
+
+## 长文版
+
+### 我做了一个不会让生产报错变成乱码的 Python 混淆器
+
+代码混淆有一个经常被忽略的问题：类名和函数名变成 `I0`、`I1` 以后，
+外部的人不容易直接读代码了，但开发者自己收到的生产报错也可能失去意义，
+Claude Code、Cursor 之类的工具同样不知道这些名字原来是什么。
+
+这正是我做 [pyobfus](https://github.com/zhurong2020/pyobfus) 的出发点。
+它是一个基于 Python AST 的代码混淆器。Community Edition 使用 Apache-2.0，
+支持 FastAPI、Django、Flask、Pydantic、Click 和 SQLAlchemy 的框架预设，
+也提供稳定的 JSON CLI 与 MCP server。
+
+最关键的是，它可以在构建时单独保存名称映射：
+
+```bash
+pip install pyobfus
+pyobfus --check src/ --json
+pyobfus src/ -o dist/ --save-mapping mapping.json
+```
+
+客户拿到混淆后的代码，开发者自己安全保存 `mapping.json`。收到生产环境堆栈后：
+
+```bash
+pyobfus --unmap --trace error.log --mapping mapping.json --json
+```
+
+原始名称恢复以后，既可以自己排查，也可以继续交给 AI 编程助手分析。
+
+刚发布的 0.5.4 还补上了一个 Pro 设备绑定缺口。此前 `--bind-device` 已经
+保护 Selective Opacity 的 L3 key，但 String Vault 的 key 仍可能作为常量写入
+产物。现在每个 Vault 都有独立 salt，并在运行时根据绑定设备派生 key：
+
+```bash
+pyobfus src/ -o dist/ --level pro --vault --bind-device
+```
+
+这里也需要把边界说清楚：Community Edition 的目标是提高随手阅读和复制的
+成本，不是不可逆加密；即便使用 Pro，加密的函数或字符串在运行时仍然需要解密，
+能够控制进程的攻击者仍可能通过动态分析或内存提取获得内容。本地 trial 也是便利
+控制，而不是安全边界。
+
+0.5.4 的发布 CI 包含 1,046 个通过的 Core 测试、1 个 skip、90% coverage，
+覆盖 Python 3.9–3.14 和 Linux/macOS/Windows；Core、MCP、端到端测试分别运行。
+
+下一步我不想继续凭感觉堆功能。候选方向包括 ML/model-serving preset、签名构建
+来源清单、PyInstaller 集成指南，以及 MCP tool description 的完整性校验。如果你
+正在交付 Python 软件，欢迎告诉我哪个才是实际阻塞，也欢迎直接提交能够复现的
+框架兼容问题。
+
+项目：<https://github.com/zhurong2020/pyobfus>
+
+文档：<https://pyobfus.readthedocs.io/>
+
+DOI：<https://doi.org/10.5281/zenodo.20846053>
+
+## V2EX / 短版
+
+发布了 pyobfus 0.5.4：一个基于 AST 的 Python 混淆器，Community Edition 是
+Apache-2.0。它和常见混淆工具最大的区别不是多一种变换，而是可以安全保存
+`mapping.json`，收到生产堆栈后用 `--unmap` 恢复原始名称，再交给开发者或 AI
+助手调试。
+
+0.5.4 把 `--bind-device` 扩展到了每个 Pro String Vault key；正常用法是
+`pyobfus src/ -o dist/ --level pro --vault --bind-device`，没有 `build` 子命令。
+
+边界也写明了：它提高静态阅读成本，不承诺阻止控制运行进程的攻击者。当前 CI 是
+Python 3.9–3.14 × 三系统，Core/MCP/端到端测试分开跑。
+
+GitHub：<https://github.com/zhurong2020/pyobfus>

--- a/_drafts/launch-v0.5.4/devto.md
+++ b/_drafts/launch-v0.5.4/devto.md
@@ -1,0 +1,93 @@
+---
+title: "I built a Python obfuscator that keeps production traces debuggable"
+published: false
+tags: python, opensource, security, claudecode
+canonical_url: https://github.com/zhurong2020/pyobfus
+---
+
+Python obfuscation usually creates a second problem: the same renamed symbols
+that slow down a casual reader also make production crashes useless to the
+developer and their coding assistant.
+
+That trade-off is why I built
+[pyobfus](https://github.com/zhurong2020/pyobfus), an AST-based Python
+obfuscator with a reversible debugging path. The Apache-2.0 core is public, the
+commercial Pro source stays separately licensed, and both are developed in the
+same public repository.
+
+The basic workflow is deliberately ordinary:
+
+```bash
+pip install pyobfus
+pyobfus --check src/ --json
+pyobfus src/ -o dist/ --save-mapping mapping.json
+```
+
+The distributed code contains renamed symbols. The mapping file stays with the
+developer. When a crash arrives:
+
+```bash
+pyobfus --unmap --trace error.log --mapping mapping.json --json
+```
+
+The result restores the original identifiers before the trace goes back to
+Claude Code, Cursor, or a human debugger. Framework presets preserve reflective
+APIs for FastAPI, Django, Flask, Pydantic, Click, and SQLAlchemy. A separate
+`pyobfus-mcp` package exposes the risk scan, configuration, obfuscation, and
+reverse-mapping workflow as machine-readable MCP tools.
+
+## What changed in 0.5.4
+
+The latest release closes a concrete device-binding gap in the Pro pipeline.
+Before 0.5.4, `--bind-device` protected the Selective Opacity L3 key but Runtime
+String Vault keys could still be emitted as baked constants. In 0.5.4, every
+vault gets its own salt and derives its key from the bound machine at runtime.
+The normal syntax is:
+
+```bash
+pyobfus src/ -o dist/ --level pro --vault --bind-device
+```
+
+There is no `pyobfus build` subcommand. I am calling that out because several
+older release notes used the wrong shorthand and copying it produced a path
+error.
+
+The release CI recorded 1,046 passing core tests, one skip, and 90% coverage.
+Core, MCP, and end-to-end suites run separately across Python 3.9 through 3.14
+on Linux, macOS, and Windows.
+
+## The threat model is intentionally limited
+
+The community tier raises the cost of casual source inspection; it is not a
+claim of irreversible protection. Pro can encrypt selected function bodies and
+vaulted strings, bind decryption to a machine, seal code objects, and scrub
+tracebacks. A determined attacker controlling a running process can still use
+dynamic analysis or extract material from memory. The local Pro trial is also a
+convenience control, not a security boundary; that limitation is documented and
+pinned by tests.
+
+If the requirement is nation-state resistance, an encrypted VM or hardware
+boundary is the more honest answer. If the requirement is distributing Python
+to customers while keeping routine debugging workable, this is the niche I am
+trying to serve.
+
+## What I need feedback on
+
+The next work should come from real use rather than another speculative feature.
+The candidates are:
+
+- an ML/model-serving preset;
+- a signed build-provenance manifest;
+- a PyInstaller integration cookbook;
+- integrity verification for MCP tool descriptions.
+
+I am especially interested in reproducible cases where a framework breaks,
+where the mapping workflow is awkward, or where the documented threat model is
+wrong. Issues and code are at
+[github.com/zhurong2020/pyobfus](https://github.com/zhurong2020/pyobfus).
+
+If you use pyobfus in research, the project has a version-independent Zenodo
+DOI: [10.5281/zenodo.20846053](https://doi.org/10.5281/zenodo.20846053).
+
+*Disclosure: I maintain pyobfus and license the optional Pro edition. Nobody
+sponsored this post.*

--- a/_drafts/launch-v0.5.4/github-poll.md
+++ b/_drafts/launch-v0.5.4/github-poll.md
@@ -1,0 +1,35 @@
+# GitHub Discussions poll
+
+## Title
+
+```text
+Which real-world integration should pyobfus prioritize next?
+```
+
+## Body
+
+pyobfus 0.5.4 is now published and the release/CI cleanup is complete. Before I
+start another feature, I want to choose from evidence rather than implement the
+most interesting idea in isolation.
+
+If you distribute Python code today, which of these would remove the most real
+friction? Please add a comment if the honest answer is “none of these.” A short
+description of your packaging/deployment workflow is more valuable than a bare
+vote.
+
+## Options
+
+1. **ML/model-serving preset** — preserve serving-framework reflection points
+   and make model-path/weight secrets easier to vault.
+2. **Signed build-provenance manifest** — locally verifiable file/config/tool
+   digests, with optional signing.
+3. **PyInstaller integration cookbook** — a tested obfuscate-then-bundle flow,
+   including mapping and hidden-import handling.
+4. **MCP tool-description integrity** — detect a changed or poisoned MCP tool
+   surface across installs and updates.
+
+## Close the loop
+
+Review after 14 days or 10 votes, whichever comes first. Publish the result and
+the selected next step in a comment; do not silently turn the winner into an
+unbounded promise.

--- a/_drafts/launch-v0.5.4/reddit-python.md
+++ b/_drafts/launch-v0.5.4/reddit-python.md
@@ -1,0 +1,37 @@
+# r/Python monthly showcase entry
+
+The 2026 r/Python rules direct project showcases to the designated showcase
+thread. Do not use the old standalone-post draft without re-checking the rules.
+
+## Suggested comment
+
+**pyobfus 0.5.4 — AST obfuscation with reversible production traces**
+
+Repository: <https://github.com/zhurong2020/pyobfus>
+
+What it does: pyobfus renames Python identifiers through the AST, preserves
+reflection-sensitive APIs through FastAPI/Django/Flask/Pydantic/Click/SQLAlchemy
+presets, and can save a mapping that restores original names in a production
+traceback. It also has JSON CLI output and an MCP server for coding agents.
+
+Who it is for: small teams distributing commercial Python that want to make
+casual source inspection harder without giving up readable crash triage. It is
+not a substitute for a hardware security boundary or protection against an
+attacker controlling a running process.
+
+What is new: 0.5.4 extends Pro device binding to every Runtime String Vault key.
+Each vault receives a distinct salt; the key is derived from the bound host at
+runtime instead of shipping as a baked constant.
+
+Quick start:
+
+```bash
+pip install pyobfus
+pyobfus --check src/ --json
+pyobfus src/ -o dist/ --save-mapping mapping.json
+```
+
+The Apache-2.0 core is fully usable on its own; optional Pro code is separately
+licensed and source-separated. I maintain the project. The most useful feedback
+would be a framework compatibility case, a weakness in the stated threat model,
+or which integration is missing from a real packaging pipeline.

--- a/_drafts/launch-v0.5.4/show-hn.md
+++ b/_drafts/launch-v0.5.4/show-hn.md
@@ -1,0 +1,48 @@
+# Show HN submission
+
+Current Show HN rules require something people can run and currently restrict
+accounts that are not yet familiar with the community. Submit only when the
+maintainer account is eligible and available to answer questions.
+
+## Title and URL
+
+```text
+Show HN: Pyobfus – Obfuscate Python without losing readable crash traces
+https://github.com/zhurong2020/pyobfus
+```
+
+## First comment
+
+Author here. I built pyobfus around a problem I had not seen other Python
+obfuscators treat as a first-class constraint: production code can be hard to
+read without making its crash reports useless to the developer and their coding
+assistant.
+
+The Apache-2.0 core mangles the AST, understands common framework reflection
+points, and writes a mapping that can reverse an obfuscated traceback locally.
+There is also an MCP server, so the preflight/config/obfuscate/unmap flow can be
+called by Claude Code, Cursor, and other agents without scraping terminal text.
+
+Version 0.5.4 also device-binds each Pro String Vault key. The honest boundary:
+core obfuscation raises the cost of casual inspection; even encrypted wrappers
+do not stop an attacker who controls a running process and can dump memory.
+
+Quick try:
+
+```text
+pip install pyobfus
+pyobfus --check src/ --json
+pyobfus src/ -o dist/ --save-mapping mapping.json
+```
+
+The current release has 1,046 passing core tests across Python 3.9–3.14. I
+would value hard questions about the threat model, broken frameworks, or the
+mapping workflow more than feature applause.
+
+## Response principles
+
+- Do not describe AST obfuscation as irreversible security.
+- State that Pro is commercial and source-separated when relevant.
+- For trial-bypass questions, link SECURITY.md and say the local trial is a
+  convenience control, not a security boundary.
+- Do not ask for votes or coordinate comments.

--- a/benchmarks/llm_resistance/README.md
+++ b/benchmarks/llm_resistance/README.md
@@ -1,0 +1,55 @@
+# LLM resistance benchmark
+
+This directory measures whether an attacker model can reconstruct a clean,
+functionally equivalent implementation from a pyobfus artifact. The complete
+method and threat model are in
+[`docs/LLM_RESISTANCE_BENCHMARK.md`](../../docs/LLM_RESISTANCE_BENCHMARK.md).
+
+## Offline validation
+
+The stub attacker proves that corpus transformation, functional scoring, and
+report generation work without an API key:
+
+```bash
+pytest benchmarks/llm_resistance/test_smoke.py -v --no-cov
+python benchmarks/llm_resistance/harness.py --attacker stub
+```
+
+Stub numbers are a harness self-test, not evidence about an LLM, and must never
+be published as model-resistance results.
+
+## Real measurement
+
+Install the Anthropic SDK in an isolated environment, set
+`ANTHROPIC_API_KEY`, choose and pre-pull a pinned Python container image, and
+pass an explicit currently available model id. Model-generated code is
+untrusted, so the real-attacker path defaults to a no-network, read-only Docker
+executor:
+
+```bash
+pip install anthropic
+docker pull python:3.12-alpine
+python benchmarks/llm_resistance/harness.py \
+  --attacker anthropic --model MODEL_ID --judge \
+  --docker-image python:3.12-alpine
+```
+
+For a publication run, replace the floating image tag with an immutable digest.
+Host execution of real model output is rejected unless
+`--unsafe-host-execution` is supplied explicitly.
+
+Outputs are written to the ignored `results/` directory. Before publishing,
+verify that C0 is near 100% recovery, inspect every failure, and deliberately
+copy the reviewed report/result into a versioned documentation location. Never
+commit an API key or raw provider response that may contain sensitive data.
+
+## Current scope
+
+- Five seed samples and six conditions (C0-C5).
+- Static source analysis only; runtime memory extraction is out of scope.
+- Functional equivalence is the primary score. The optional judge only scores
+  the prose explanation.
+- Real attacker output is scored with Docker networking disabled, a read-only
+  filesystem, dropped capabilities, and CPU/memory/process limits.
+- A credible public result still requires a real attacker run, ideally across
+  at least two model families and a larger corpus.

--- a/benchmarks/llm_resistance/attacker.py
+++ b/benchmarks/llm_resistance/attacker.py
@@ -79,7 +79,7 @@ def _extract_code(response: str) -> tuple[str, str]:
 @dataclass
 class AnthropicAttacker(Attacker):
     name: str = "anthropic"
-    model: str = "claude-sonnet-5"
+    model: str = ""
     max_tokens: int = 4096
     _prompt_path: Path = field(default=_PROMPTS / "attacker_v1.md", repr=False)
 
@@ -87,6 +87,8 @@ class AnthropicAttacker(Attacker):
         return self._prompt_path.read_text(encoding="utf-8")
 
     def deobfuscate(self, obfuscated_src: str, entrypoints: list[dict]) -> AttackResult:
+        if not self.model:
+            raise ValueError("AnthropicAttacker requires an explicit model id")
         import anthropic  # lazy: only needed for real runs
 
         prompt = (
@@ -116,7 +118,7 @@ class AnthropicAttacker(Attacker):
         }
 
 
-def make_anthropic_judge(model: str = "claude-sonnet-5"):
+def make_anthropic_judge(model: str):
     """Return a ``(explanation, ground_truth) -> int 0..3`` judge callable."""
     template = (_PROMPTS / "judge_v1.md").read_text(encoding="utf-8")
 

--- a/benchmarks/llm_resistance/corpus/roman.py
+++ b/benchmarks/llm_resistance/corpus/roman.py
@@ -1,9 +1,19 @@
 def to_roman(n):
     """Convert an integer in 1..3999 to its Roman-numeral string."""
     table = [
-        (1000, "M"), (900, "CM"), (500, "D"), (400, "CD"),
-        (100, "C"), (90, "XC"), (50, "L"), (40, "XL"),
-        (10, "X"), (9, "IX"), (5, "V"), (4, "IV"), (1, "I"),
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
     ]
     out = []
     for value, symbol in table:

--- a/benchmarks/llm_resistance/harness.py
+++ b/benchmarks/llm_resistance/harness.py
@@ -17,8 +17,11 @@ pipeline end-to-end; ``anthropic`` runs the real measurement. See
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
@@ -55,8 +58,18 @@ def entrypoints_for(meta: dict) -> list[dict]:
     return [{"name": name, "arity": arity} for name, arity in seen.items()]
 
 
-def run(attacker, judge=None, limit=None) -> dict:
+def run(
+    attacker,
+    judge=None,
+    limit=None,
+    sample_names: set[str] | None = None,
+    *,
+    executor: str = "host",
+    docker_image: str | None = None,
+) -> dict:
     samples = load_corpus(limit)
+    if sample_names is not None:
+        samples = [sample for sample in samples if sample["name"] in sample_names]
     rows = []
     for meta in samples:
         eps = entrypoints_for(meta)
@@ -92,7 +105,12 @@ def run(attacker, judge=None, limit=None) -> dict:
                 continue
 
             result = attacker.deobfuscate(obf, eps)
-            rec = S.score_recovery(result.reimplementation, meta)
+            rec = S.score_recovery(
+                result.reimplementation,
+                meta,
+                executor=executor,
+                docker_image=docker_image,
+            )
             comp = S.score_comprehension(result.explanation, meta, judge)
             rows.append(
                 {
@@ -104,6 +122,7 @@ def run(attacker, judge=None, limit=None) -> dict:
                     "recovery_note": rec["note"],
                     "comprehension": comp["comprehension"],
                     "artifact_chars": len(obf),
+                    "artifact_sha256_16": hashlib.sha256(obf.encode("utf-8")).hexdigest()[:16],
                 }
             )
 
@@ -115,6 +134,12 @@ def run(attacker, judge=None, limit=None) -> dict:
             "conditions": [c.cid for c in C.CONDITIONS],
             "pyobfus_version": _pyobfus_version(),
             "python": sys.version.split()[0],
+            "run_utc": datetime.now(timezone.utc).isoformat(),
+            "execution": {
+                "executor": executor,
+                "docker_image": docker_image,
+                "network": "none" if executor == "docker" else "host-accessible",
+            },
         },
         "rows": rows,
     }
@@ -132,25 +157,69 @@ def _pyobfus_version() -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description="LLM-deobfuscation-resistance benchmark")
     ap.add_argument("--attacker", choices=["stub", "anthropic"], default="stub")
-    ap.add_argument("--model", default="claude-sonnet-5", help="model id for anthropic attacker")
+    ap.add_argument(
+        "--model",
+        default=os.environ.get("ANTHROPIC_MODEL"),
+        help="explicit model id for anthropic attacker (or set ANTHROPIC_MODEL)",
+    )
     ap.add_argument("--judge", action="store_true", help="score comprehension (anthropic only)")
     ap.add_argument("--limit", type=int, default=None, help="limit number of samples")
+    ap.add_argument(
+        "--executor",
+        choices=["host", "docker"],
+        default=None,
+        help="scoring executor (default: host for stub, docker for real attackers)",
+    )
+    ap.add_argument(
+        "--docker-image",
+        default=os.environ.get("PYOBFUS_BENCHMARK_DOCKER_IMAGE"),
+        help="pre-pulled image tag/digest used by the docker scoring executor",
+    )
+    ap.add_argument(
+        "--unsafe-host-execution",
+        action="store_true",
+        help="allow real model-generated code to execute on this host (not recommended)",
+    )
     args = ap.parse_args()
 
     if args.attacker == "stub":
         attacker = StubAttacker()
         judge = None
     else:
+        if not args.model:
+            ap.error("--model is required for the anthropic attacker")
         attacker = AnthropicAttacker(model=args.model)
         judge = make_anthropic_judge(args.model) if args.judge else None
 
-    data = run(attacker, judge=judge, limit=args.limit)
+    executor = args.executor or ("host" if args.attacker == "stub" else "docker")
+    if args.attacker != "stub" and executor == "host" and not args.unsafe_host_execution:
+        ap.error(
+            "real attacker output defaults to --executor docker; "
+            "host execution requires --unsafe-host-execution"
+        )
+    if executor == "docker" and not args.docker_image:
+        ap.error("--docker-image is required with --executor docker")
+
+    data = run(
+        attacker,
+        judge=judge,
+        limit=args.limit,
+        executor=executor,
+        docker_image=args.docker_image,
+    )
 
     RESULTS.mkdir(exist_ok=True)
     (RESULTS / "results.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
     report_md = R.build_report(data)
     (RESULTS / "report.md").write_text(report_md, encoding="utf-8")
 
+    # Windows commonly inherits a GBK console. Keep the UTF-8 report file
+    # authoritative, but never crash after a successful run merely because a
+    # Markdown glyph is not representable on stdout.
+    try:
+        sys.stdout.reconfigure(errors="replace")
+    except (AttributeError, ValueError):
+        pass
     print(report_md)
     print(f"\nWrote {RESULTS / 'results.json'} and {RESULTS / 'report.md'}")
     return 0

--- a/benchmarks/llm_resistance/report.py
+++ b/benchmarks/llm_resistance/report.py
@@ -45,7 +45,8 @@ def build_report(data: dict) -> str:
         f"**Attacker**: `{att.get('attacker')}` ({att_desc}) · "
         f"**pyobfus** {meta.get('pyobfus_version')} · "
         f"**Python** {meta.get('python')} · "
-        f"**samples**: {meta['sample_count']}"
+        f"**samples**: {meta['sample_count']} · "
+        f"**run (UTC)**: {meta.get('run_utc', 'not recorded')}"
     )
     lines.append("")
     lines.append(
@@ -60,7 +61,9 @@ def build_report(data: dict) -> str:
     for cid in meta["conditions"]:
         a = agg.get(cid)
         if not a or a["eligible"] == 0:
-            lines.append(f"| {cid} {a['name'] if a else ''} | 0 | — | — | — | (no eligible samples) |")
+            lines.append(
+                f"| {cid} {a['name'] if a else ''} | 0 | — | — | — | (no eligible samples) |"
+            )
             continue
         srr = a["recovered"] / a["eligible"]
         resistance = 1 - srr

--- a/benchmarks/llm_resistance/scorer.py
+++ b/benchmarks/llm_resistance/scorer.py
@@ -1,9 +1,10 @@
 """Scoring for the LLM-resistance benchmark.
 
 Primary metric (objective): Semantic-Recovery -- execute the attacker's
-reimplementation against the sample's ground-truth IO vectors in an isolated
-subprocess. Recovered iff ALL vectors pass (functional equivalence). Timeouts,
-exceptions, and empty outputs count as NOT recovered, never as dropped samples.
+reimplementation against the sample's ground-truth IO vectors. Real model
+output uses a locked-down Docker executor; the host executor is only for
+trusted fixtures. Recovered iff ALL vectors pass (functional equivalence).
+Timeouts, exceptions, and empty outputs count as NOT recovered.
 
 Secondary metric (subjective, optional): Comprehension -- an auxiliary judge
 scores the attacker's free-text explanation against the ground-truth
@@ -15,6 +16,7 @@ See ``docs/LLM_RESISTANCE_BENCHMARK.md``.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -22,8 +24,9 @@ from pathlib import Path
 
 # Driver executed in a subprocess: imports the reimplementation, runs each
 # vector, prints a JSON list of {"ok": bool, "got": repr|null, "error": str|null}.
-_DRIVER = r'''
+_DRIVER = r"""
 import importlib.util, json, sys
+from pathlib import Path
 
 spec = importlib.util.spec_from_file_location("reimpl", sys.argv[1])
 results = []
@@ -35,7 +38,7 @@ except BaseException as e:  # noqa: BLE001 - report, don't crash the driver
     mod = None
     load_error = f"{type(e).__name__}: {e}"
 
-vectors = json.loads(sys.argv[2])
+vectors = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 for v in vectors:
     if mod is None:
         results.append({"ok": False, "got": None, "error": f"module load failed: {load_error}"})
@@ -47,10 +50,17 @@ for v in vectors:
     except BaseException as e:  # noqa: BLE001
         results.append({"ok": False, "got": None, "error": f"{type(e).__name__}: {e}"})
 print(json.dumps(results))
-'''
+"""
 
 
-def score_recovery(reimplementation: str, meta: dict, *, timeout: float = 10.0) -> dict:
+def score_recovery(
+    reimplementation: str,
+    meta: dict,
+    *,
+    timeout: float = 10.0,
+    executor: str = "host",
+    docker_image: str | None = None,
+) -> dict:
     """Run the attacker's reimplementation against the sample's IO vectors.
 
     Returns ``{"recovered": bool, "vectors": [...per-vector...], "note": str}``.
@@ -70,15 +80,20 @@ def score_recovery(reimplementation: str, meta: dict, *, timeout: float = 10.0) 
         return {"recovered": False, "vectors": [], "note": "empty attacker output"}
 
     with tempfile.TemporaryDirectory() as td:
-        reimpl = Path(td) / "reimpl.py"
+        work = Path(td)
+        reimpl = work / "reimpl.py"
+        driver = work / "driver.py"
+        vectors_file = work / "vectors.json"
         reimpl.write_text(reimplementation, encoding="utf-8")
+        driver.write_text(_DRIVER, encoding="utf-8")
+        vectors_file.write_text(json.dumps(vectors), encoding="utf-8")
         try:
-            proc = subprocess.run(
-                [sys.executable, "-c", _DRIVER, str(reimpl), json.dumps(vectors)],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
+            if executor == "host":
+                proc = _run_on_host(driver, reimpl, vectors_file, timeout)
+            elif executor == "docker":
+                proc = _run_in_docker(work, timeout, docker_image)
+            else:
+                raise ValueError(f"unknown benchmark executor: {executor}")
         except subprocess.TimeoutExpired:
             return {"recovered": False, "vectors": [], "note": "execution timeout"}
 
@@ -93,6 +108,75 @@ def score_recovery(reimplementation: str, meta: dict, *, timeout: float = 10.0) 
 
     recovered = len(per_vector) == len(vectors) and all(r["ok"] for r in per_vector)
     return {"recovered": recovered, "vectors": per_vector, "note": ""}
+
+
+def _run_on_host(
+    driver: Path, reimpl: Path, vectors_file: Path, timeout: float
+) -> subprocess.CompletedProcess[str]:
+    """Execute trusted benchmark code locally; this is not a security sandbox."""
+    return subprocess.run(
+        [sys.executable, "-I", "-B", str(driver), str(reimpl), str(vectors_file)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _run_in_docker(
+    work: Path, timeout: float, image: str | None
+) -> subprocess.CompletedProcess[str]:
+    """Execute untrusted model output in a locked-down, offline container."""
+    docker = shutil.which("docker")
+    if docker is None:
+        raise RuntimeError("Docker is required to score real attacker output")
+    if not image:
+        raise RuntimeError("an explicit --docker-image is required for reproducibility")
+
+    # Refuse an implicit network pull during a measurement. The operator must
+    # pull and inspect the chosen image beforehand, then record that exact tag
+    # (preferably a digest) in the run metadata.
+    inspected = subprocess.run(
+        [docker, "image", "inspect", image], capture_output=True, text=True, timeout=30
+    )
+    if inspected.returncode != 0:
+        raise RuntimeError(
+            f"Docker image {image!r} is not available locally; pull it before the run"
+        )
+
+    return subprocess.run(
+        [
+            docker,
+            "run",
+            "--rm",
+            "--network",
+            "none",
+            "--read-only",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges",
+            "--memory",
+            "128m",
+            "--pids-limit",
+            "64",
+            "--cpus",
+            "0.5",
+            "--user",
+            "65534:65534",
+            "--mount",
+            f"type=bind,src={work.resolve()},dst=/work,readonly",
+            image,
+            "python",
+            "-I",
+            "-B",
+            "/work/driver.py",
+            "/work/reimpl.py",
+            "/work/vectors.json",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout + 5,
+    )
 
 
 def score_comprehension(explanation: str, meta: dict, judge) -> dict:

--- a/benchmarks/llm_resistance/test_smoke.py
+++ b/benchmarks/llm_resistance/test_smoke.py
@@ -30,8 +30,9 @@ def _rows_for(data, sample):
 
 
 def test_stub_pipeline_discriminates():
-    # limit=1 -> just luhn (c4-eligible, not c5), keeps the subprocess count low.
-    data = harness.run(StubAttacker(), judge=None, limit=1)
+    # Select luhn explicitly. ``limit=1`` used to depend on luhn sorting first,
+    # which stopped being true when billing_auth was added.
+    data = harness.run(StubAttacker(), judge=None, sample_names={"luhn"})
     rows = _rows_for(data, "luhn")
 
     # Control recovers (echoed source == original); the sanity gate in the design.

--- a/docs/.well-known/ai-catalog.json
+++ b/docs/.well-known/ai-catalog.json
@@ -1,0 +1,32 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "pyobfus",
+    "identifier": "did:web:pyobfus.readthedocs.io"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:pyobfus.readthedocs.io:server:pyobfus-mcp",
+      "displayName": "pyobfus MCP Server",
+      "type": "application/mcp-server+json",
+      "url": "https://raw.githubusercontent.com/zhurong2020/pyobfus/main/pyobfus_mcp/server.json",
+      "capabilities": [
+        "scan_project",
+        "obfuscate_file",
+        "obfuscate_package",
+        "unmap_traceback",
+        "validate_config",
+        "protect_project",
+        "recommend_tier",
+        "start_pro_trial"
+      ],
+      "description": "Obfuscate Python projects and reverse-map protected stack traces through a local, no-phone-home MCP server.",
+      "representativeQueries": [
+        "scan this Python project for obfuscation risks",
+        "protect this FastAPI package and verify the result",
+        "obfuscate this Python file without breaking public APIs",
+        "map this obfuscated traceback back to the original source"
+      ]
+    }
+  ]
+}

--- a/docs/AGENTIC_DISCOVERABILITY_2026-06-22.md
+++ b/docs/AGENTIC_DISCOVERABILITY_2026-06-22.md
@@ -108,11 +108,19 @@ This is the explicit "AI 查询" the user named — being the tool Claude/ChatGP
 { "mcpServers": { "pyobfus": { "command": "uvx", "args": ["pyobfus-mcp"] } } }
 ```
 
-### 🟢 Gap 5 (emerging, early-bird) — ARD `ai-catalog.json`
+### ✅ Gap 5 (implemented locally 2026-07-20) — ARD `ai-catalog.json`
 
 **Agentic Resource Discovery (ARD)** — open spec from Google + a Linux Foundation working group, **announced late May 2026** (≈4 weeks ago). A provider hosts a machine-readable **`ai-catalog.json`** at a well-known path; it lists the provider's MCP servers, A2A agents, OpenAPI tools, etc. *"A static JSON file on a CDN is a valid ARD publisher — no proprietary SDK."*
 
 pyobfus has a docs domain (readthedocs) and a GitHub Pages-capable repo. Publishing an `ai-catalog.json` that points at `pyobfus-mcp` is a **2–3 hour, on-brand, first-mover** move: pyobfus gets to credibly say it supports the newest agent-discovery standard the same month it shipped. Spec: `agenticresourcediscovery.org/spec`, repo `github.com/ards-project/ard-spec` (Apache-2.0).
+
+**2026-07-20 update:** the ARD 1.0 manifest now lives at
+`docs/.well-known/ai-catalog.json`; `mkdocs.yml` explicitly includes the hidden
+directory and CI validates the JSON. Read the Docs versions content under
+`/en/latest/`, so publication is not complete until the project admin adds an
+exact redirect from `/.well-known/ai-catalog.json` to
+`/en/latest/.well-known/ai-catalog.json` and verifies HTTPS, JSON content type,
+CORS `*`, and the final body after the docs build deploys.
 
 ---
 
@@ -129,7 +137,8 @@ pyobfus has a docs domain (readthedocs) and a GitHub Pages-capable repo. Publish
 - [ ] Reuse PyArmor trial-limit + test-count facts as citable, sourced statistics (Gap 3)
 
 **Wave C — emerging bet (one afternoon):**
-- [ ] Publish `ai-catalog.json` per ARD spec at the docs domain (Gap 5)
+- [~] ARD manifest implemented and CI-validated; deploy + Read the Docs root
+  redirect/header verification remain admin actions (Gap 5)
 - [ ] (optional) `npx pyobfus-mcp` thin wrapper to also occupy the npm "room"
 
 ---

--- a/docs/LLM_RESISTANCE_BENCHMARK.md
+++ b/docs/LLM_RESISTANCE_BENCHMARK.md
@@ -99,7 +99,11 @@ For each (sample, condition, attacker) triple:
 
 1. The attacker returns a clean Python reimplementation.
 2. The harness **executes** that reimplementation against the sample's
-   ground-truth IO test vectors in an isolated subprocess (timeout + no network).
+   ground-truth IO test vectors. Real model output defaults to a locked-down
+   Docker container (no network, read-only filesystem, dropped capabilities,
+   CPU/memory/process limits, timeout). The ordinary host subprocess is used
+   only for the trusted offline stub unless an operator explicitly accepts the
+   unsafe override.
 3. **Recovered = passes ALL vectors** (functional equivalence). Partial credit is
    *not* given for the primary metric — semantic recovery is binary per sample.
 
@@ -143,8 +147,11 @@ secondary metric. **CS never overrides SRR** in the headline.
     into `results.json` so a run is fully reproducible.
   - (future) `OpenAIAttacker` / others — to reproduce Acoda's multi-model table.
 - Every run records: attacker class, model id, prompt hash, pyobfus version,
-  Python version, UTC date, per-sample seeds. No `Math.random`/wall-clock
-  nondeterminism in the harness itself.
+  Python version, UTC date, scoring executor/container image, and each generated
+  artifact's content hash. The
+  obfuscator intentionally uses cryptographic randomness, so byte-identical
+  artifacts are not expected; the functional metric and exact inputs remain
+  reproducible.
 
 ### Fairness rules (so the number is honest, not marketing)
 

--- a/docs/NEXT_FEATURE_DECISION.md
+++ b/docs/NEXT_FEATURE_DECISION.md
@@ -1,0 +1,46 @@
+# Next Feature Decision
+
+**Status:** waiting for launch feedback. Do not start a large feature merely to
+fill the gap while the poll is running.
+
+## Decision window
+
+Open the launch poll using
+[`_drafts/launch-v0.5.4/github-poll.md`](https://github.com/zhurong2020/pyobfus/blob/main/_drafts/launch-v0.5.4/github-poll.md),
+then review it after **14 days or 10 votes**, whichever comes first. Record the
+opening date, closing trigger, links, and raw counts below.
+
+| Signal | ML preset | Provenance manifest | PyInstaller guide | MCP integrity |
+|---|---:|---:|---:|---:|
+| Poll votes | — | — | — | — |
+| Substantive comments | — | — | — | — |
+| Launch-channel requests | — | — | — | — |
+| Existing issue reactions | — | — | — | — |
+
+## Selection rule
+
+1. Prefer described workflows and reproducible pain over bare votes.
+2. Require at least two independent users describing the same need before a
+   large implementation; otherwise choose the smallest reversible experiment.
+3. Break ties by expected user value, then implementation cost, then fit with
+   pyobfus's AST + AI-debuggable scope.
+4. Publish the result and rationale before implementation starts.
+
+## Candidate experiments
+
+- **ML/model-serving preset:** first add a failing fixture for one real serving
+  framework and validate preserved reflection points.
+- **Signed provenance manifest:** first define a versioned JSON schema and an
+  unsigned deterministic manifest; add signing only after the contract settles.
+- **PyInstaller guide:** first prove one clean obfuscate-then-bundle example in
+  CI before expanding into a cookbook.
+- **MCP integrity:** first threat-model which metadata can be trusted locally and
+  demonstrate a changed-tool-surface detector.
+
+## Decision record
+
+- Poll opened: pending external publication
+- Review trigger reached: pending
+- Selected candidate: pending evidence
+- First bounded experiment: pending
+- Rationale/link: pending

--- a/docs/POST_V0.4_TODO.md
+++ b/docs/POST_V0.4_TODO.md
@@ -4,9 +4,9 @@
 
 **Use as cold-start cheat sheet** when resuming work after a session break. This doc supersedes ad-hoc TODO scattered in chat; future Claude sessions should read this first.
 
-> **Current executable handoff (2026-07-19):** start with
-> [`RESUME_PLAN_2026-07-19.md`](RESUME_PLAN_2026-07-19.md), whose status header
-> records what shipped. This file remains the longer historical backlog.
+> **Current executable handoff (2026-07-20):** use the prioritized list below.
+> [`RESUME_PLAN_2026-07-19.md`](RESUME_PLAN_2026-07-19.md) is a frozen record of
+> the 0.5.4 release session; its unchecked boxes are not current work.
 >
 > **0.5.4 published 2026-07-19.** Vault-key device binding landed (PR #19), so
 > the "vault keys still ship as baked literals" scope boundary below is CLOSED.
@@ -15,11 +15,38 @@
 > roots. Remaining open: #22 (mypy gate), the launch wave, P2-18 benchmark
 > evidence.
 
+## Current prioritized TODO (2026-07-20)
+
+1. ✅ **Documentation truth sweep — completed 2026-07-20.** Active surfaces use
+   the real `pyobfus SRC -o OUT --level pro --<flag>` syntax; 0.5.4 and the
+   release-CI baseline are current; old release checklists are marked frozen.
+2. **Launch wave** — refresh and publish dev.to → Show HN → Reddit → Chinese
+   channels; open a GitHub feedback poll and record pre/post metrics.
+3. ✅ **Issue #22 / mypy gate — implemented locally 2026-07-20.** Core, Pro,
+   and MCP (72 source files) now report zero errors; mypy stays on the 1.20
+   line while Python 3.9 is supported; CI is blocking. Await remote CI before
+   closing the issue.
+4. **P2-18 benchmark-first evidence — harness hardened locally 2026-07-20.**
+   The offline smoke job is blocking in CI and records model/date/artifact
+   hashes. A credentialed real-model run is still required before publishing
+   any resistance number; stub output is explicitly not evidence.
+5. **Discoverability and citation — repository work complete 2026-07-20.** DOI,
+   README/PyPI/Read the Docs citation surfaces are present. ARD metadata is
+   added and CI-validated; deployment still needs a Read the Docs root redirect
+   and header check. PulseMCP remains an external listing follow-up.
+6. **Next feature selection — evidence gate prepared.** The poll copy and
+   [`NEXT_FEATURE_DECISION.md`](NEXT_FEATURE_DECISION.md) define the 14-day /
+   10-vote trigger and decision rubric. Selection deliberately waits for real
+   launch feedback.
+
+Large speculative features and a JOSS re-submission remain deferred until the
+project has demonstrated third-party adoption.
+
 ---
 
-## 🔜 Forward TODO (updated 2026-06-22)
+## Historical execution record (frozen; not the current TODO)
 
-**Published to PyPI**: 0.5.0 (2026-06-18) → 0.5.1 + pyobfus-mcp 0.3.1 (2026-06-22) → 0.5.2 (2026-06-22, patch) → **0.5.3 (2026-07-07)** — the three deferred build-fusion flags (`--period` / `--opacity-config` / `--bind-device`). Patent gate cleared 2026-06-17 (申请号 202610712171X). Python 3.8 dropped (floor 3.9). Merged to main; nothing is held anymore. Open items, roughly in priority order:
+**Release history**: 0.5.0 (2026-06-18) → 0.5.1 + pyobfus-mcp 0.3.1 (2026-06-22) → 0.5.2 (2026-06-22, patch) → 0.5.3 (2026-07-07) → **0.5.4 (2026-07-19)**. Patent gate cleared 2026-06-17 (申请号 202610712171X). Python 3.8 dropped (floor 3.9). The numbered material below preserves the decisions and evidence from those releases; it is not an executable checklist.
 
 1. ✅ **DONE 2026-06-22 — published 0.5.1 + pyobfus-mcp 0.3.1.** pyobfus 0.5.1 (`pyobfus build --flag` fusion) merged to main + tagged `v0.5.1` → OIDC PyPI publish (wheel+sdist live, PEP 740 attestations; release run `27938471463`). Then `mcp-v0.3.1` → pyobfus-mcp 0.3.1 to PyPI (run `27939165475`) + `mcp-publisher publish` → MCP Registry 0.3.1 isLatest. Glama auto re-indexes. Order honored (mcp dep `pyobfus>=0.5.1`).
 

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -50,7 +50,7 @@ pyobfus/
 │   ├── wrangler.toml     # Worker configuration
 │   └── README.md         # Worker management guide
 │
-├── tests/                # Test suite (1033 tests, 90% coverage)
+├── tests/                # Core test suite (1,000+ tests, 90% coverage)
 │   ├── test_core/        # Tests for core modules
 │   ├── test_transformers/# Tests for transformers
 │   ├── integration/      # Integration tests

--- a/docs/RESUME_PLAN_2026-07-19.md
+++ b/docs/RESUME_PLAN_2026-07-19.md
@@ -35,10 +35,15 @@
 >
 > **Next up, in order:** P1.4 launch wave · #22 mypy gate · P2.1 benchmark
 > evidence. The P0 queue is clear, so P2 work is no longer blocked.
+>
+> **Archive note (2026-07-20):** the detailed checklists below are frozen
+> planning evidence from before 0.5.4 shipped. Their unchecked boxes do not
+> represent current work. The live ordered backlog is at the top of
+> `POST_V0.4_TODO.md`.
 
-**Purpose**: current, executable handoff for the next maintainer/agent session.
-Start here, then use [`POST_V0.4_TODO.md`](POST_V0.4_TODO.md) for the longer
-historical backlog and [`ROADMAP.md`](ROADMAP.md) for strategic candidates.
+**Purpose**: historical handoff from the 0.5.4 release session. Use
+[`POST_V0.4_TODO.md`](POST_V0.4_TODO.md) for the current ordered backlog and
+[`ROADMAP.md`](ROADMAP.md) for strategic candidates.
 
 **Security note**: this is a public-repository document. It records impact,
 decisions, and remediation work without reproducing copy-paste trial-bypass
@@ -292,4 +297,3 @@ not point elsewhere:
 5. Once CI coverage is real, perform the PR #19 human review.
 
 Do not begin P2 feature work while any P0 item above remains open.
-

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,9 +9,9 @@ This document outlines **future plans** for pyobfus. For released version histor
 
 ## Current Status
 
-**Latest (2026-07-07)**: **pyobfus 0.5.3 released** — completes the 0.5.3 build-fusion surface deferred from 0.5.1: `--period <N>` (crypto-bound run-counter), `--opacity-config <opacity.toml>` (pattern-driven L3 encryption resolved by *pre-mangle* qualname via decorator injection — no name-map coupling), and `--bind-device` / `--bind-device-id` (device-locked L3: the emitted `_LAYER_KEY` is rewritten into a runtime `bind_device_key(current_machine_id(), salt)` re-derivation, so decryption only succeeds on the bound device). 1033 tests; via OIDC + PEP 740 attestations. **pyobfus-mcp stays 0.3.1** (no tool-surface change; its `pyobfus>=0.5.1` floor resolves to 0.5.3). Vault-key (`_VAULT_KEY_*`) device binding is the open 0.5.4 follow-up.
+**Latest (2026-07-19)**: **pyobfus 0.5.4 released** — `--bind-device` now derives both Selective Opacity L3 keys and every Runtime String Vault key from the bound machine, closing the remaining baked-Vault-key scope boundary. The release CI recorded **1046 passed / 1 skipped / 90% coverage** in the core suite; Core, MCP, and end-to-end roots run as separate jobs across Python 3.9-3.14 and three operating systems. Published through OIDC with PEP 740 attestations. **pyobfus-mcp stays 0.3.1** because the MCP tool surface did not change.
 
-**Prior (2026-06-22)**: **pyobfus 0.5.2 + pyobfus-mcp 0.3.1 published to PyPI** (0.5.0 was 2026-06-18; 0.5.1 same day). 0.5.1 fused the 6 v0.5 Pro mechanisms into `pyobfus build` flags; **0.5.2 is a patch fixing `--seal-code`/`--vault` on Python 3.9/3.10** (seal hash pinned to marshal v2; `zip(strict=)` dropped from the vault pass; 1025 core tests). mcp 0.3.1 names the v0.5 mechanisms in pro-funnel copy (dep `pyobfus>=0.5.1`); MCP Registry 0.3.1 isLatest; all via OIDC + PEP 740 attestations. Patent gate cleared 2026-06-17 (申请号 202610712171X). Ran the **agentic-discoverability Wave A** (Smithery Skill + mcp.so + `uvx` zero-install + sharpened server.json blurb) — see `docs/AGENTIC_DISCOVERABILITY_2026-06-22.md`. **JOSS paper desk-rejected 2026-06-24** (issue `openjournals/joss-reviews#10788`; grounds = scope/significance, not quality: "private-dev-then-public" + no demonstrated third-party reuse). Pivoted to the free path: **Zenodo concept DOI `10.5281/zenodo.20846053`** now minted and propagated (CITATION.cff, README badge, ORCID, arong.eu.org). See `docs/JOSS_REJECTION_20260624.md`.
+**Prior (2026-06-22)**: **pyobfus 0.5.2 + pyobfus-mcp 0.3.1 published to PyPI** (0.5.0 was 2026-06-18; 0.5.1 same day). 0.5.1 fused the 6 v0.5 Pro mechanisms into flags on the normal obfuscation command; **0.5.2 is a patch fixing `--seal-code`/`--vault` on Python 3.9/3.10** (seal hash pinned to marshal v2; `zip(strict=)` dropped from the vault pass; 1025 core tests). mcp 0.3.1 names the v0.5 mechanisms in pro-funnel copy (dep `pyobfus>=0.5.1`); MCP Registry 0.3.1 isLatest; all via OIDC + PEP 740 attestations. Patent gate cleared 2026-06-17 (申请号 202610712171X). Ran the **agentic-discoverability Wave A** (Smithery Skill + mcp.so + `uvx` zero-install + sharpened server.json blurb) — see `docs/AGENTIC_DISCOVERABILITY_2026-06-22.md`. **JOSS paper desk-rejected 2026-06-24** (issue `openjournals/joss-reviews#10788`; grounds = scope/significance, not quality: "private-dev-then-public" + no demonstrated third-party reuse). Pivoted to the free path: **Zenodo concept DOI `10.5281/zenodo.20846053`** now minted and propagated (CITATION.cff, README badge, ORCID, arong.eu.org). See `docs/JOSS_REJECTION_20260624.md`.
 
 ### Snapshot (2026-05-07, historical)
 
@@ -19,7 +19,7 @@ See [CHANGELOG.md](../CHANGELOG.md) for the latest release and version history.
 
 - **pyobfus 0.4.0** released 2026-04-22 (AI-native CLI + framework presets + reverse stack-trace mapping)
 - **pyobfus-mcp 0.1.2** released 2026-05-07 (emergency fix for `FastMCP.__init__()` `version=` kwarg drift in mcp SDK ≥ 1.20; see `pyobfus_mcp/CHANGELOG.md`)
-- 1033 tests, 90% coverage (multi-OS CI/CD across Python 3.9-3.14)
+- At the current 0.5.4 baseline: 1046 core tests passed, 1 skipped, 90% coverage (multi-OS CI/CD across Python 3.9-3.14)
 - Full Pro feature set available
 - Parallel file processing support (`-j/--jobs`)
 - PyPI downloads: pyobfus ~337/month, pyobfus-mcp ~239/month (real users only, ex-mirrors)
@@ -49,28 +49,28 @@ The previous v0.4.0 plan (Enhanced Key Obfuscation, Code Compression) has been d
 
 Core functionality that unblocks real user scenarios and becomes the foundation for AI integration.
 
-- [ ] **P0-1: `pyobfus --check` pre-flight mode** — Scan project for `eval`/`exec`/`getattr`/dynamic attribute access, framework reflection points, `__all__` exports. Output JSON risk report with `ai-hint` field suggesting next command. _Estimate: 1 week_
-- [ ] **P0-2: `pyobfus unmap` reverse mapping command** — Input error stacktrace + mapping.json → output original variable-name trace. Unlocks "AI can still debug obfuscated code". _Estimate: 3-5 days_
-- [ ] **P0-3: Framework presets** — `--preset fastapi|django|flask|pydantic|click` with built-in exclusion rules for each framework's reflection points. _Estimate: 1 week_
-- [ ] **P0-4: AI-friendly CLI** — Global `--json` output mode, structured error messages with `ai-hint` field, machine-readable exit codes. _Estimate: 2-3 days_
-- [ ] **P0-5: `pyobfus init`** — Scan project → detect framework → generate `pyobfus.yaml` with auto-exclude list. One-command onboarding. _Estimate: 3-5 days_
+- [x] **P0-1: `pyobfus --check` pre-flight mode** — Scan project for `eval`/`exec`/`getattr`/dynamic attribute access, framework reflection points, `__all__` exports. Output JSON risk report with `ai-hint` field suggesting next command. _Shipped 0.4.0._
+- [x] **P0-2: `pyobfus unmap` reverse mapping command** — Input error stacktrace + mapping.json → output original variable-name trace. Unlocks "AI can still debug obfuscated code". _Shipped 0.4.0._
+- [x] **P0-3: Framework presets** — `--preset fastapi|django|flask|pydantic|click` with built-in exclusion rules for each framework's reflection points. _Shipped 0.4.0._
+- [x] **P0-4: AI-friendly CLI** — Global `--json` output mode, structured error messages with `ai_hint` field, machine-readable exit codes. _Shipped 0.4.0._
+- [x] **P0-5: `pyobfus init`** — Scan project → detect framework → generate `pyobfus.yaml` with auto-exclude list. One-command onboarding. _Shipped 0.4.0._
 
 ### P1 - AI Ecosystem Integration (Weeks 4-6)
 
 Builds on top of P0 primitives to make pyobfus appear natively in the AI-assisted workflow.
 
-- [ ] **P1-1: `pyobfus-mcp` server** (separate package) — Expose P0 tools as Model Context Protocol server for Claude Desktop / Claude Code / Cursor / Windsurf. _Estimate: 1 week_
-- [ ] **P1-2: `llms.txt` + `llms-full.txt`** — Deploy at repo root and docs site. _Estimate: 2 hours_
-- [ ] **P1-3: AI integration templates** — `templates/ai-integration/` with CLAUDE.md, .cursorrules, AGENTS.md, windsurfrules.md. _Estimate: 1 day_
-- [ ] **P1-4: PyPI metadata overhaul** — New keyword-dense description, Project-URL additions (MCP Server, AI Guide), Development Status → Beta. _Estimate: 1 hour_
-- [ ] **P1-5: Incremental obfuscation** — AST hash caching, only process changed files. Enables CI/CD embedding. _Estimate: 1-2 weeks_
+- [x] **P1-1: `pyobfus-mcp` server** (separate package) — Expose P0 tools as Model Context Protocol server for Claude Desktop / Claude Code / Cursor / Windsurf. _Shipped; current package 0.3.1._
+- [x] **P1-2: `llms.txt` + `llms-full.txt`** — Deploy at repo root and docs site. _Shipped._
+- [x] **P1-3: AI integration templates** — `templates/ai-integration/` with CLAUDE.md, .cursorrules, AGENTS.md, windsurfrules.md. _Shipped._
+- [x] **P1-4: PyPI metadata overhaul** — New keyword-dense description, Project-URL additions (MCP Server, AI Guide), Development Status → Production/Stable. _Shipped._
+- [x] **P1-5: Incremental obfuscation** — Project-level AST/config hash cache behind `--incremental`, reusing an unchanged successful build. _Shipped._
 
 ### Branding & Discoverability (Parallel, Week 1)
 
 - [ ] Reserve PyPI alias packages: `python-obfuscator`, `pyobfuscator`, `py-obfuscator` (if available)
 - [ ] Add GitHub topics: `python-obfuscator`, `code-obfuscator`, `ast-obfuscation`, `mcp-server`, `claude-code`, `cursor`, `llm-tools`
-- [ ] README: add pronunciation / alias line: "pyobfus — the Python obfuscator"
-- [ ] Upgrade classifier: `Development Status :: 3 - Alpha` → `4 - Beta`
+- [x] README: add pronunciation / alias line: "pyobfus — the Python obfuscator"
+- [x] Upgrade classifier: Core is now `Development Status :: 5 - Production/Stable`; MCP remains Beta
 
 ---
 
@@ -80,7 +80,7 @@ Builds on top of P0 primitives to make pyobfus appear natively in the AI-assiste
 
 ### P2 - Differentiation Layer
 
-- [x] **P2-1: Selective Opacity (Layered Protection)** — per-symbol layers (transparent / ai-readable / obfuscated / encrypted); L3 = AES-256-GCM with lazy `__code__` materialization. _Shipped 0.5.0 2026-06-18 (mechanism + API; combined `pyobfus build` flag fusion in 0.5.1)._
+- [x] **P2-1: Selective Opacity (Layered Protection)** — per-symbol layers (transparent / ai-readable / obfuscated / encrypted); L3 = AES-256-GCM with lazy `__code__` materialization. _Shipped 0.5.0 2026-06-18 (mechanism + API; combined Pro-flag fusion in 0.5.1)._
 - [ ] **P2-2: VSCode Extension** — Right-click obfuscate + yaml IntelliSense + status bar. Marketplace as a new distribution channel. _Estimate: 1-2 weeks_
 - [x] **P2-3: `--strip-ai-artifacts` mode** — Removes AI provenance markers (`Generated by Claude`, `Co-Authored-By: Claude`, `🤖 Generated with`, ...) from docstrings + attribution dunders (`__author__` etc.). Conservative attribution-only matching; arbitrary string literals untouched; comments already dropped by the AST round-trip. Community-tier, 27 tests. _Shipped 2026-06-06 (branch `feat/strip-ai-artifacts`)._
 - [ ] **P2-4: Import obfuscation (Pro)** — Top-level imports → runtime `importlib` + encrypted strings. Closes gap with PyArmor Pro. _Estimate: 1-2 weeks_
@@ -94,7 +94,7 @@ The four items below were surfaced by a competitive feature scan against PyArmor
 - [x] **P2-7: Forensic watermarking / `--fingerprint <buyer-id>` (Pro)** — per-buyer deterministic key derivation (`forensic_seed` / `WatermarkRNG` / `derive_layer_key`) for piracy traceback. _Shipped 0.5.0 2026-06-18 (Pro-layer key watermarking + API; Core rename-RNG single-seed integration in 0.5.1)._
 - [x] **P2-8: Hardware / time / period license binding (Pro)** — device / expiry / run-count binding woven into the AES-GCM decryption path (`pyobfus_pro.license_binding`): the license gate is the GCM tag check itself, no separate patchable check. _Shipped 0.5.0 2026-06-18 (mechanism + API; `--bind-device` / `--expire-hard` / `--period` build flags in 0.5.1)._
 - [x] **P2-9: `@seal_code` integrity decorator (Pro)** — build-time bytecode hash baked in; runtime detection of in-memory patching, with layer-aware sealing for L3 functions. _Shipped 0.5.0 2026-06-18 (decorator + build pass; combined-flag fusion in 0.5.1)._
-- [x] **P2-10: `--scrub-traceback` production traceback encryption (Pro)** — hybrid RSA-2048-OAEP + AES-256-GCM error-ID encryption; developer reverses with the new **`pyobfus-unscrub`** CLI. _Shipped 0.5.0 2026-06-18 (`pyobfus-unscrub` CLI + build pass; `pyobfus build --scrub-traceback` fusion in 0.5.1)._
+- [x] **P2-10: `--scrub-traceback` production traceback encryption (Pro)** — hybrid RSA-2048-OAEP + AES-256-GCM error-ID encryption; developer reverses with the new **`pyobfus-unscrub`** CLI. _Shipped 0.5.0 2026-06-18 (`pyobfus-unscrub` CLI + build pass; `--scrub-traceback` fusion in 0.5.1)._
 
 ---
 
@@ -130,11 +130,11 @@ Benefits: simpler test matrix (~15% faster CI), one less dependency, and elimina
 
 Surfaced by a fresh scan against PyArmor 9.2 / Nuitka / SourceDefender / CodeEnigma plus arXiv 2025-2026 (2512.16538 LLM-vs-obfuscation, 2410.05797 CodeCipher) and the 2026 AI-agent tool-discovery landscape. All stay inside the AST + AI-native lane. Full analysis: `docs/AGENTIC_DISCOVERABILITY_2026-06-22.md`.
 
-- [ ] **P2-17: Signed obfuscation provenance manifest (Pro/Core)** — `pyobfus build` emits a signed JSON manifest (files obfuscated, config hash, tool version, mapping digest; optional sigstore). Rides the 2026 SLSA/SBOM/provenance wave, reuses the existing PEP 740 muscle, and is something PyArmor's phone-home-on-build model structurally can't offer (no local-verifiable provenance). _Estimate: 3-5 days_
-- [ ] **P2-18: LLM-deobfuscation-resistance mode + benchmark** — a `--llm-resistant` preset and/or a published "LLM semantic-recovery rate X%" benchmark report. Uniquely on-brand for an AI-native obfuscator (no competitor can credibly quantify resistance *to AI*); strong launch-content story even as a benchmark-only first cut. _Estimate: benchmark 2-3 days; mode 1-2 weeks_
+- [ ] **P2-17: Signed obfuscation provenance manifest (Pro/Core)** — a normal pyobfus invocation emits a signed JSON manifest (files obfuscated, config hash, tool version, mapping digest; optional sigstore). Rides the 2026 SLSA/SBOM/provenance wave, reuses the existing PEP 740 muscle, and is something PyArmor's phone-home-on-build model structurally can't offer (no local-verifiable provenance). _Estimate: 3-5 days_
+- [~] **P2-18: LLM-deobfuscation-resistance mode + benchmark** — the benchmark harness, five-sample corpus, functional scorer, reproducibility metadata, locked-down real-output executor, and blocking offline CI smoke job are implemented. A credentialed real-model run and reviewed public result remain; stub output is not evidence. A `--llm-resistant` preset stays deferred until the benchmark justifies it. _Estimate: measurement + review 1 day; mode 1-2 weeks if justified_
   - **Publication dual-track**: the JOSS paper (`paper/`) is the *software-description* paper (free, low novelty bar). This benchmark is the seed for a *separate research* paper with a novel contribution — target a software-protection / security venue (SPRO, ESORICS, ACSAC, AsiaCCS) or JSS/EMSE, with an arXiv cs.CR preprint for visibility. The two papers don't conflict (different artifacts) and the research paper drives traffic back to the tool. Do NOT submit the same software paper to both JOSS and SoftwareX (dual-publication); SoftwareX (~€2.5k APC, SCIE IF~3) is the only "indexed upgrade" alternative *instead of* JOSS for this paper.
 - [ ] **P2-19: ML/model-serving preset (`--preset ml`)** — protect inference-wrapper code, route model-path / weight-file constants into the Runtime String Vault, surface pickle-safety guidance. Rides the HuggingFace pickle-RCE wave; near-zero architecture cost (the preset mechanism already exists). _Estimate: 3-5 days_
-- [~] **P2-20: Agentic discoverability (Wave A, mostly shipped 2026-06-22)** — be findable by AI agents across every discovery surface, not just human SEO. Done: Smithery via the **Skill** channel (`zhurong2020/pyobfus-protect`; Smithery's MCP-publish is remote-HTTP-only and a non-fit for a local-execution tool — the Skill channel is the right path), mcp.so listing, `uvx pyobfus-mcp` zero-install + a sharpened ≤100-char `server.json` blurb, `smithery.yaml`. Pending: PulseMCP (passive weekly ingest of the Official Registry; email fallback), ARD `ai-catalog.json` early-bird, and GEO/AEO content (answer-first openings, named-number facts, FAQ schema) folded into the launch wave.
+- [~] **P2-20: Agentic discoverability (Wave A, mostly shipped 2026-06-22; ARD repo work 2026-07-20)** — be findable by AI agents across every discovery surface, not just human SEO. Done: Smithery via the **Skill** channel (`zhurong2020/pyobfus-protect`; Smithery's MCP-publish is remote-HTTP-only and a non-fit for a local-execution tool — the Skill channel is the right path), mcp.so listing, `uvx pyobfus-mcp` zero-install + a sharpened ≤100-char `server.json` blurb, `smithery.yaml`, and an ARD 1.0 manifest included in the verified MkDocs build. Pending: Read the Docs root redirect/header verification, PulseMCP external follow-up, and GEO/AEO launch content.
 
 ---
 
@@ -217,7 +217,8 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 
 ---
 
-**Last Updated**: 2026-07-07 — added the "Additions from 2026-07-07 research scan" section: external re-validation of P2-17 (SLSA/attestation adoption + tooling gap), P2-18 (LLM-deobfuscation research explosion + Acoda prior art → promote to top strategic priority), P2-19; plus two new candidates P2-21 (pyobfus-mcp tool-description integrity / rug-pull resistance) and P2-22 (honest-comparison content vs statically-unpackable PyArmor bytecode). Refreshed download figures (~1,180/mo pyobfus + ~400/mo mcp). Fixed the Glama listing note (recurring manual Build-steps bump; bumped to 0.3.1 on 07-07).
-**Prior**: 2026-06-22 — Marked 0.5.2 published (patch: `--seal-code`/`--vault` Python 3.9/3.10 fixes, PR #18); earlier same day 0.5.1 + pyobfus-mcp 0.3.1 published; added the "Additions from 2026-06-22 scan" section: P2-17 (signed provenance manifest), P2-18 (LLM-deobfuscation-resistance mode + benchmark), P2-19 (`--preset ml`), and P2-20 (agentic discoverability, Wave A mostly shipped — Smithery Skill / mcp.so / uvx / server.json). Source: 2026-06-22 competitive + AI-agent-discoverability scan (see `docs/AGENTIC_DISCOVERABILITY_2026-06-22.md`).
-**Previous**: 2026-05-09 — Added P2-7..P2-10 to v0.5.0 (forensic watermarking, license binding, integrity seal, scrub-traceback) and a v0.5.1 section with P2-11..P2-16. Expanded "What We Won't Do" with bytecode-VM virtualization, anti-VM detection, standalone runtime folder model. Source: 2026-05-09 competitive scan (PyArmor 9.2.x, Nuitka Commercial, Sourcedefender, vmp-protector 1.0.0, obfuscator-ai, arXiv 2512.16538/2510.11251).
-**Earlier**: 2026-04-22 — Strategic reshape after AI-era competitive analysis.
+**Last Updated**: 2026-07-22 — synchronized the post-0.5.4 execution state: the blocking mypy gate and hardened P2-18 benchmark harness are prepared for remote CI; ARD discovery metadata and launch drafts are ready; next-feature work remains gated on launch feedback.
+**Prior**: 2026-07-07 — added the "Additions from 2026-07-07 research scan" section: external re-validation of P2-17 (SLSA/attestation adoption + tooling gap), P2-18 (LLM-deobfuscation research explosion + Acoda prior art → promote to top strategic priority), P2-19; plus two new candidates P2-21 (pyobfus-mcp tool-description integrity / rug-pull resistance) and P2-22 (honest-comparison content vs statically-unpackable PyArmor bytecode). Refreshed download figures (~1,180/mo pyobfus + ~400/mo mcp). Fixed the Glama listing note (recurring manual Build-steps bump; bumped to 0.3.1 on 07-07).
+**Previous**: 2026-06-22 — Marked 0.5.2 published (patch: `--seal-code`/`--vault` Python 3.9/3.10 fixes, PR #18); earlier same day 0.5.1 + pyobfus-mcp 0.3.1 published; added the "Additions from 2026-06-22 scan" section: P2-17 (signed provenance manifest), P2-18 (LLM-deobfuscation-resistance mode + benchmark), P2-19 (`--preset ml`), and P2-20 (agentic discoverability, Wave A mostly shipped — Smithery Skill / mcp.so / uvx / server.json). Source: 2026-06-22 competitive + AI-agent-discoverability scan (see `docs/AGENTIC_DISCOVERABILITY_2026-06-22.md`).
+**Earlier**: 2026-05-09 — Added P2-7..P2-10 to v0.5.0 (forensic watermarking, license binding, integrity seal, scrub-traceback) and a v0.5.1 section with P2-11..P2-16. Expanded "What We Won't Do" with bytecode-VM virtualization, anti-VM detection, standalone runtime folder model. Source: 2026-05-09 competitive scan (PyArmor 9.2.x, Nuitka Commercial, Sourcedefender, vmp-protector 1.0.0, obfuscator-ai, arXiv 2512.16538/2510.11251).
+**Original reshape**: 2026-04-22 — Strategic reshape after AI-era competitive analysis.

--- a/docs/V0.5_RELEASE_PLAN.md
+++ b/docs/V0.5_RELEASE_PLAN.md
@@ -1,6 +1,6 @@
 # pyobfus v0.5.0 — Public Release Plan (Phase 5)
 
-**Status**: ✅ **SHIPPED — 0.5.0 published to PyPI 2026-06-18, 0.5.1 (build-flag fusion) + pyobfus-mcp 0.3.1 published 2026-06-22.** This doc is now historical (the operational checklist is complete). Forward work lives in `docs/POST_V0.4_TODO.md`.
+**Status**: ✅ **SHIPPED — 0.5.0 published to PyPI 2026-06-18, 0.5.1 (build-flag fusion) + pyobfus-mcp 0.3.1 published 2026-06-22.** This doc is now historical (the operational checklist is complete). Forward work lives in `docs/POST_V0.4_TODO.md`. References to `pyobfus build` below preserve obsolete release-planning wording; the real syntax is `pyobfus SRC -o OUT --level pro --<flag>` and there is no `build` subcommand.
 
 > Original status (kept for record): 🟢 0.5.0 BUILT 2026-06-18, awaiting push/publish (maintainer-gated). Patent gate cleared 2026-06-17 (初步审查合格通知书, 申请号 202610712171X, priority 2026-05-22); the six mechanisms are merged, tested (1016 pass / 1 skip), packaged, and `dist/` artifacts pass `twine check`. The deferred `pyobfus build --flag` fusion shipped in 0.5.1 (1024 tests).
 
@@ -132,7 +132,7 @@ pass and injecting `@opacity(Layer.ENCRYPTED)` (decorator survives mangling —
 no name map). `--bind-device` rewrites the emitted `_LAYER_KEY` into a runtime
 `bind_device_key(current_machine_id(), salt)` re-derivation, leaving opacity.py /
 vault.py untouched. Open follow-up: vault-key (`_VAULT_KEY_*`) device binding
-(0.5.4). 1033 tests. Awaiting version bump + tag + publish. Implementation: `pyobfus_pro/build_fusion.py`
+(completed in 0.5.4). The 0.5.4 release CI recorded 1046 passed / 1 skipped / 90% coverage. Implementation: `pyobfus_pro/build_fusion.py`
 (vault PRE-pass + opacity/seal/scrub/expire POST-passes) wired into
 `pyobfus/cli.py::_obfuscate_file`. Publishing 0.5.1 also refreshes the PyPI
 long-description (the 0.5.0 page kept pre-3.8-drop text).

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ title: pyobfus - Modern Python Code Obfuscator
     <li style="margin: 0.5em 0;">🔐 <strong>AES-256 String Encryption</strong>: Military-grade encryption for strings</li>
     <li style="margin: 0.5em 0;">🛡️ <strong>Anti-Debugging Checks</strong>: Detect and prevent debugging attempts</li>
     <li style="margin: 0.5em 0;">📅 <strong>License Embedding</strong>: Expiration dates, machine binding, run limits</li>
-    <li style="margin: 0.5em 0;">🧱 <strong>v0.5 build-fusion mechanisms</strong> (compose via <code>pyobfus build</code>): Selective Opacity, Seal-Code, String Vault, Scrub-Traceback, Fingerprint, Expire-Hard</li>
+    <li style="margin: 0.5em 0;">🧱 <strong>v0.5 build-fusion mechanisms</strong> (compose via <code>pyobfus SRC -o OUT --level pro --&lt;flag&gt;</code>): Selective Opacity, Seal-Code, String Vault, Scrub-Traceback, Fingerprint, Expire-Hard</li>
     <li style="margin: 0.5em 0;">⚡ <strong>Configuration Presets</strong>: One-command setup (trial, commercial, library)</li>
     <li style="margin: 0.5em 0;">🔄 <strong>Lifetime Updates</strong>: All future Pro features included</li>
     <li style="margin: 0.5em 0;">💻 <strong>Up to 3 Devices</strong>: Use on multiple machines</li>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -62,8 +62,9 @@ uvx pyobfus-mcp
 
 ## Pro build-fusion mechanisms (require trial or license)
 
-The `pyobfus build` command composes six named Pro protection mechanisms via
-per-mechanism flags (0.5.1+), which stack on top of the base obfuscation:
+The normal obfuscation command composes six named Pro protection mechanisms via
+per-mechanism flags (0.5.1+), which stack on top of the base obfuscation. Use
+`pyobfus SRC -o OUT --level pro --<flag>`; there is no `build` subcommand:
 
 - `--selective-opacity` — Selective Opacity: opaque, per-layer-keyed wrappers around chosen callables
 - `--seal-code` — Seal-Code: tamper-evident code-object seal that aborts on modification
@@ -73,7 +74,7 @@ per-mechanism flags (0.5.1+), which stack on top of the base obfuscation:
 - `--expire-hard` — Expire-Hard: hard build expiry that refuses to run past a deadline
 - `--period` (0.5.3) — run-count guard capping how many times a build may execute
 - `--opacity-config <toml>` (0.5.3) — target opacity by qualified name via a TOML config
-- `--bind-device` / `--bind-device-id` (0.5.3) — device-lock: derive the opacity layer key at runtime from the host
+- `--bind-device` / `--bind-device-id` (0.5.3; extended to Vault keys in 0.5.4) — device-lock: derive the opacity layer key AND each Runtime String Vault key at runtime from the host, so neither ships as a baked literal and a wrong machine is refused
 
 ## AI agent tips
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -271,7 +271,7 @@ Same JSON shape as the CLI: `status`, `error_type`, `ai_hint`, etc.
 
 ## Versioning
 
-pyobfus follows semver. AI-native features (preflight, init, unmap, JSON CLI, MCP server) are baseline. v0.5 adds the `pyobfus build` Pro fusion flags (`--selective-opacity --seal-code --vault --scrub-traceback --fingerprint --expire-hard`, plus `--period --opacity-config --bind-device` in 0.5.3) that compose the six Pro protection mechanisms. Breaking changes to JSON schemas are flagged with a `version` field bump.
+pyobfus follows semver. AI-native features (preflight, init, unmap, JSON CLI, MCP server) are baseline. v0.5 adds composable Pro flags (`--selective-opacity --seal-code --vault --scrub-traceback --fingerprint --expire-hard`, plus `--period --opacity-config --bind-device` in 0.5.3) to the normal `pyobfus SRC -o OUT --level pro --<flag>` command. There is no `build` subcommand. Breaking changes to JSON schemas are flagged with a `version` field bump.
 
 ## Links
 

--- a/llms.txt
+++ b/llms.txt
@@ -62,8 +62,9 @@ uvx pyobfus-mcp
 
 ## Pro build-fusion mechanisms (require trial or license)
 
-The `pyobfus build` command composes six named Pro protection mechanisms via
-per-mechanism flags (0.5.1+), which stack on top of the base obfuscation:
+The normal obfuscation command composes six named Pro protection mechanisms via
+per-mechanism flags (0.5.1+), which stack on top of the base obfuscation. Use
+`pyobfus SRC -o OUT --level pro --<flag>`; there is no `build` subcommand:
 
 - `--selective-opacity` — Selective Opacity: opaque, per-layer-keyed wrappers around chosen callables
 - `--seal-code` — Seal-Code: tamper-evident code-object seal that aborts on modification

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,11 @@ site_name: pyobfus Documentation
 site_url: https://pyobfus.readthedocs.io
 site_description: Modern Python Code Obfuscator
 
+# MkDocs excludes dot-directories by default. ARD requires this exact
+# well-known path, so opt it back into the generated site.
+exclude_docs: |
+  !/.well-known/
+
 repo_name: zhurong2020/pyobfus
 repo_url: https://github.com/zhurong2020/pyobfus
 
@@ -16,6 +21,8 @@ nav:
   - License Activation: LICENSE_ACTIVATION_GUIDE.md
   - Project Structure: PROJECT_STRUCTURE.md
   - Integration Testing: INTEGRATION_TESTING.md
+  - LLM Resistance Benchmark: LLM_RESISTANCE_BENCHMARK.md
+  - Next Feature Decision: NEXT_FEATURE_DECISION.md
   - How to Cite: CITATION.md
 
 markdown_extensions:

--- a/pyobfus/cli.py
+++ b/pyobfus/cli.py
@@ -1682,7 +1682,7 @@ def _apply_trace_markers(output_path: Path, mapping_path: str) -> Optional[str]:
         marker_id = json.loads(mp.read_text(encoding="utf-8")).get("marker_id")
     except (OSError, ValueError):
         return None
-    if not marker_id:
+    if not isinstance(marker_id, str) or not marker_id:
         return None
 
     block = _trace_marker_block(marker_id, mp.name)

--- a/pyobfus/config_validator.py
+++ b/pyobfus/config_validator.py
@@ -4,6 +4,7 @@ Configuration file validator.
 Validates pyobfus YAML configuration files and reports errors/warnings.
 """
 
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 import yaml
@@ -306,11 +307,11 @@ def find_config_file(
     # Check for pyproject.toml
     pyproject_path = start_path / "pyproject.toml"
     if pyproject_path.exists():
-        try:
+        if sys.version_info >= (3, 11):
             import tomllib
-        except ImportError:
+        else:
             try:
-                import tomli as tomllib  # type: ignore
+                import tomli as tomllib
             except ImportError:
                 return None, None
 

--- a/pyobfus/core/cache.py
+++ b/pyobfus/core/cache.py
@@ -27,7 +27,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 
 from pyobfus import __version__ as PYOBFUS_VERSION
 
@@ -154,7 +154,7 @@ class BuildCache:
             return None
         if data.get("version") != MANIFEST_VERSION:
             return None
-        return data
+        return cast(Dict[str, Any], data)
 
     def save_manifest(self, signature: Dict, output_files: List[str]) -> None:
         """Persist the manifest after a successful full build."""

--- a/pyobfus/core/generator.py
+++ b/pyobfus/core/generator.py
@@ -278,7 +278,7 @@ class CodeGenerator:
             import black
 
             mode = black.Mode(line_length=line_length)
-            return black.format_str(source_code, mode=mode)
+            return cast(str, black.format_str(source_code, mode=mode))
         except ImportError:
             # If black not available, return as-is
             return source_code

--- a/pyobfus/core/mapping.py
+++ b/pyobfus/core/mapping.py
@@ -90,7 +90,7 @@ class ObfuscationMapping:
         )
 
         # Duck-typed: global_table exposes .get_all_modules() and .get_module_exports(m)
-        modules = getattr(global_table, "get_all_modules", lambda: [])()
+        modules: Iterable[str] = getattr(global_table, "get_all_modules", lambda: [])()
         get_exports = getattr(global_table, "get_module_exports", None)
         if get_exports is None:
             return m

--- a/pyobfus/transformers/ai_artifact_stripper.py
+++ b/pyobfus/transformers/ai_artifact_stripper.py
@@ -168,12 +168,14 @@ class AIArtifactStripper(BaseTransformer):
             )
         # __author__: str = "..."
         if isinstance(stmt, ast.AnnAssign):
-            value = stmt.value
-            if value is None:
+            annotated_value = stmt.value
+            if annotated_value is None:
                 return False
-            if not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+            if not (
+                isinstance(annotated_value, ast.Constant) and isinstance(annotated_value.value, str)
+            ):
                 return False
-            if not _is_ai_marker(value.value):
+            if not _is_ai_marker(annotated_value.value):
                 return False
             return isinstance(stmt.target, ast.Name) and stmt.target.id in _ATTRIBUTION_DUNDERS
         return False

--- a/pyobfus_mcp/pyproject.toml
+++ b/pyobfus_mcp/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 dependencies = [
     # >=0.5.1: the pro-funnel copy references the v0.5 Pro mechanisms and their
-    # `pyobfus build` flags (Selective Opacity / watermarking / Vault /
+    # composable flags (Selective Opacity / watermarking / Vault /
     # --scrub-traceback / @seal_code), which land in pyobfus 0.5.1. Publish
     # pyobfus 0.5.1 before this MCP release.
     "pyobfus>=0.5.1",

--- a/pyobfus_pro/license_binding/binding.py
+++ b/pyobfus_pro/license_binding/binding.py
@@ -43,6 +43,7 @@ import hashlib
 import os
 import platform
 import shutil
+from typing import cast
 import tempfile
 from pathlib import Path
 
@@ -228,7 +229,7 @@ def bind_device_key(
         salt=bytes(build_salt),
         iterations=iterations,
     )
-    return kdf.derive(machine_id.encode("utf-8"))
+    return cast(bytes, kdf.derive(machine_id.encode("utf-8")))
 
 
 # ---------------------------------------------------------------------------

--- a/pyobfus_pro/runtime/opacity.py
+++ b/pyobfus_pro/runtime/opacity.py
@@ -44,7 +44,7 @@ import functools
 import marshal
 import secrets
 import types
-from typing import Callable, TypeVar
+from typing import Callable, TypeVar, cast
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -109,7 +109,7 @@ def _encrypt_code(code: types.CodeType, key: bytes | bytearray) -> bytes:
     plaintext = marshal.dumps(code)
     nonce = secrets.token_bytes(_NONCE_SIZE)
     aesgcm = AESGCM(bytes(key))
-    ciphertext_with_tag = aesgcm.encrypt(nonce, plaintext, associated_data=None)
+    ciphertext_with_tag = cast(bytes, aesgcm.encrypt(nonce, plaintext, associated_data=None))
     return nonce + ciphertext_with_tag
 
 

--- a/pyobfus_pro/runtime/scrub.py
+++ b/pyobfus_pro/runtime/scrub.py
@@ -31,6 +31,7 @@ import base64
 import os
 import sys
 import traceback as _traceback
+from typing import cast
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import hashes, serialization
@@ -138,7 +139,7 @@ def _unscrub_payload(error_id: str, private_key_pem: bytes) -> bytes:
         raise ScrubError(f"unable to decrypt AES key (wrong private key?): {exc}") from exc
 
     try:
-        return AESGCM(aes_key).decrypt(nonce, ciphertext, associated_data=None)
+        return cast(bytes, AESGCM(aes_key).decrypt(nonce, ciphertext, associated_data=None))
     except InvalidTag as exc:
         raise ScrubError(f"unable to decrypt payload (corrupted blob): {exc}") from exc
 

--- a/pyobfus_pro/runtime/vault.py
+++ b/pyobfus_pro/runtime/vault.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import os
 import secrets as _secrets
 from collections.abc import Mapping
+from typing import cast
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import hashes
@@ -139,7 +140,7 @@ class Vault:
             salt=salt,
             iterations=iterations,
         )
-        return kdf.derive(passphrase.encode("utf-8"))
+        return cast(bytes, kdf.derive(passphrase.encode("utf-8")))
 
     def get(self, name: str) -> str:
         """Decrypt and return the value for ``name``.
@@ -156,7 +157,8 @@ class Vault:
         nonce = blob[:_NONCE_SIZE]
         ciphertext = blob[_NONCE_SIZE:]
         try:
-            return self._aesgcm.decrypt(nonce, ciphertext, associated_data=None).decode("utf-8")
+            plaintext = cast(bytes, self._aesgcm.decrypt(nonce, ciphertext, associated_data=None))
+            return plaintext.decode("utf-8")
         except InvalidTag as exc:
             raise VaultError(
                 f"unable to decrypt entry {name!r} " f"(wrong master key or tampered blob)"

--- a/pyobfus_pro/transformers/opacity.py
+++ b/pyobfus_pro/transformers/opacity.py
@@ -176,15 +176,17 @@ def transform_module(
             new_body.append(stmt)
             continue
 
-        layer = next((lyr for node, lyr in target_layers if node is stmt), None)
-        if layer is None:
+        resolved_layer: Layer | None = next(
+            (candidate for node, candidate in target_layers if node is stmt), None
+        )
+        if resolved_layer is None:
             new_body.append(stmt)
             continue
 
         # Strip the @opacity(...) decorator on every layer.
         stmt.decorator_list = [d for d in stmt.decorator_list if not _is_opacity_decorator(d)]
 
-        if layer is Layer.ENCRYPTED:
+        if resolved_layer is Layer.ENCRYPTED:
             cipher_const_name = f"{_CIPHER_PREFIX}{stmt.name}"
             cipher_assign = ast.Assign(
                 targets=[ast.Name(id=cipher_const_name, ctx=ast.Store())],

--- a/pyobfus_pro/transformers/vault.py
+++ b/pyobfus_pro/transformers/vault.py
@@ -61,7 +61,6 @@ from __future__ import annotations
 
 import ast
 import secrets
-from collections.abc import Iterable
 
 from pyobfus_pro.runtime.vault import Vault
 
@@ -349,4 +348,4 @@ def _ensure_vault_class_import(tree: ast.Module) -> None:
     tree.body.insert(insert_at, new_import)
 
 
-__all__: Iterable[str] = ("VaultBuildError", "collect_vault_names", "transform_module")
+__all__ = ("VaultBuildError", "collect_vault_names", "transform_module")

--- a/pyobfus_pro/unscrub.py
+++ b/pyobfus_pro/unscrub.py
@@ -32,6 +32,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
+from typing import cast
 
 from pyobfus_pro.runtime.scrub import ScrubError, unscrub_error_id
 
@@ -108,7 +109,8 @@ def _resolve_error_id(args: argparse.Namespace) -> str:
 
     if args.error_id_file is not None:
         try:
-            return args.error_id_file.read_text(encoding="utf-8").strip()
+            error_id_file = cast(Path, args.error_id_file)
+            return error_id_file.read_text(encoding="utf-8").strip()
         except OSError as exc:
             print(f"{_PROG_NAME}: error: cannot read --error-id-file: {exc}", file=sys.stderr)
             raise SystemExit(_EXIT_USAGE) from exc
@@ -123,7 +125,7 @@ def _resolve_error_id(args: argparse.Namespace) -> str:
         )
         raise SystemExit(_EXIT_USAGE)
 
-    return args.error_id.strip()
+    return cast(str, args.error_id).strip()
 
 
 def _read_private_key(path: Path) -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "black>=22.0",
-    # mypy 2.x no longer accepts python_version=3.9; keep the type-check target
-    # aligned with pyobfus's supported runtime floor until Python 3.9 is dropped.
-    "mypy>=1.20,<2.0",
+    # mypy 2.x no longer accepts python_version=3.9, while mypy 1.20+ itself
+    # requires Python 3.10. Allow 1.19.x on the Python 3.9 runtime jobs.
+    "mypy>=1.19,<2.0",
     "types-PyYAML>=6.0",
     # CI runs on 3.11+ but mypy targets 3.9, where config validation imports
     # the tomllib backport.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyobfus"
 version = "0.5.4"
-description = "pyobfus — the Python obfuscator. AST-based name mangling + framework presets (FastAPI/Django/Pydantic/Click/SQLAlchemy) + reverse stack-trace mapping for AI debugging in Claude Code / Cursor. The modern PyArmor alternative: same protection, traces stay debuggable. Apache-2.0."
+description = "pyobfus — the Python obfuscator. AST-based name mangling + framework presets (FastAPI/Django/Pydantic/Click/SQLAlchemy) + reverse stack-trace mapping for AI debugging in Claude Code / Cursor. A transparent PyArmor alternative: AST-level protection with debuggable traces. Apache-2.0."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"
 license = {text = "Apache-2.0"}
@@ -56,7 +56,13 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "black>=22.0",
-    "mypy>=1.0",
+    # mypy 2.x no longer accepts python_version=3.9; keep the type-check target
+    # aligned with pyobfus's supported runtime floor until Python 3.9 is dropped.
+    "mypy>=1.20,<2.0",
+    "types-PyYAML>=6.0",
+    # CI runs on 3.11+ but mypy targets 3.9, where config validation imports
+    # the tomllib backport.
+    "tomli>=2.0",
     "ruff>=0.1.0",
 ]
 
@@ -102,7 +108,7 @@ python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
-ignore_missing_imports = true
+follow_imports = "skip"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

- make mypy blocking across Core, Pro, and MCP and clear the 72-file source baseline
- harden the LLM-resistance benchmark with deterministic reporting, isolated execution support, and an offline CI smoke job
- add ARD discovery metadata, current launch drafts, next-feature decision gates, and public-copy trust corrections

## Why

The post-0.5.4 follow-up work was complete locally but not yet reviewable or covered by remote CI. This PR moves those changes onto a focused delivery branch, closes the remaining type-check baseline, and prepares the discovery/launch surfaces without publishing unmeasured model-resistance claims.

Closes #22.

## Impact

- type regressions in shipped packages now fail CI
- benchmark plumbing is tested offline; real-model results remain manual and unpublished
- Read the Docs can emit the ARD well-known catalog
- launch copy reflects the current 0.5.4 trust boundary and avoids absolute security claims

## Validation

- Core: 1046 passed, 1 skipped; 90% coverage
- MCP: 73 passed
- integration: 7 passed
- benchmark smoke: 2 passed
- Black: 147 files unchanged
- Ruff: all checks passed
- mypy: no issues in 72 source files
- JSON catalog validation and MkDocs build passed

The local-only `.workbuddy/` directory is intentionally excluded.
