### PR TITLE
feat: --preset ml + model-serving preflight guidance (P2-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrappers. Preserves the framework-dispatched method names external code
   actually calls by exact name (`predict`/`predict_proba`/`fit`/`transform`/
   `forward`/`generate`/`encode` — sklearn, PyTorch's `nn.Module.__call__`,
-  HuggingFace conventions), preserves parameter names, excludes
-  model/checkpoint/weight artifact paths, and pairs with new `--check`
-  guidance for unsafe pickle/`torch.load`/model loading plus Runtime String
-  Vault routing hints for model-path literals.
+  HuggingFace conventions), excludes model/checkpoint/weight artifact
+  paths, and pairs with new `--check` guidance for unsafe pickle/
+  `torch.load`/model loading plus Runtime String Vault routing hints for
+  model-path literals. Sets `preserve_param_names=True` for consistency
+  with every other framework preset, though that flag does not currently
+  preserve parameter identifiers end-to-end for any preset (issue #25).
 
 ## [0.5.4] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--preset ml`** — community-tier model-serving preset for inference
+  wrappers. Preserves the framework-dispatched method names external code
+  actually calls by exact name (`predict`/`predict_proba`/`fit`/`transform`/
+  `forward`/`generate`/`encode` — sklearn, PyTorch's `nn.Module.__call__`,
+  HuggingFace conventions), preserves parameter names, excludes
+  model/checkpoint/weight artifact paths, and pairs with new `--check`
+  guidance for unsafe pickle/`torch.load`/model loading plus Runtime String
+  Vault routing hints for model-path literals.
+
 ## [0.5.4] - 2026-07-19
 
 **Feature + honesty release.** Closes the last device-binding scope boundary

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [`skills/`](skills/) for the skill and install details. (This is distinct fr
 - **`pyobfus --init src/`** — zero-config onboarding: scans the project, detects FastAPI/Django/Pydantic/Click/SQLAlchemy, and writes a ready-to-use `pyobfus.yaml`.
 - **`pyobfus --unmap --trace error.log --mapping mapping.json`** — reverse obfuscated identifiers in a production stack trace so you can debug (or hand the trace to an AI assistant) without reversing the obfuscation itself.
 - **`pyobfus … --save-mapping mapping.json --trace-marker`** — stamp each obfuscated file with a `# pyobfus:obfuscated` header (id + mapping filename + the exact `--unmap` command) so an AI agent that lands in an obfuscated file from a traceback immediately knows it's pyobfus output and how to reverse the names.
-- **Framework-aware presets** — `--preset fastapi | django | flask | pydantic | click | sqlalchemy` with built-in exclusions for dispatch methods, decorators, ORM fields, migrations, and dependency-injection parameters.
+- **Framework-aware presets** — `--preset fastapi | django | flask | pydantic | click | sqlalchemy | ml` with built-in exclusions for dispatch methods, decorators, ORM fields, migrations, model-serving wrappers, and dependency-injection parameters.
 - **Global `--json`** — every CLI mode (`obfuscate`, `--check`, `--unmap`, `--init`) emits the same structured schema with an `ai_hint` field, ready for Claude Code, Cursor, Windsurf, and MCP servers to consume.
 
 ## Features

--- a/pyobfus/cli.py
+++ b/pyobfus/cli.py
@@ -242,6 +242,7 @@ except ImportError:
             "pydantic",
             "click",
             "sqlalchemy",
+            "ml",
             # Pro
             "trial",
             "commercial",
@@ -251,7 +252,7 @@ except ImportError:
         case_sensitive=False,
     ),
     help="Use a preset configuration. Community: safe/balanced/aggressive. "
-    "Framework-aware: fastapi/django/flask/pydantic/click/sqlalchemy. "
+    "Framework-aware: fastapi/django/flask/pydantic/click/sqlalchemy/ml. "
     "Pro: trial/commercial/library/maximum.",
 )
 @click.option(
@@ -1580,6 +1581,11 @@ def _handle_list_presets() -> None:
     click.echo("    Preserves ORM columns, relationships, session API")
     click.echo("    Auto-excludes alembic/, migrations/")
     click.echo("    Usage: pyobfus src/ -o dist/ --preset sqlalchemy")
+
+    click.echo("\n  ml")
+    click.echo("    Preserves model-serving wrapper APIs and model artifact paths")
+    click.echo("    Auto-excludes models/, checkpoints/, common weight files")
+    click.echo("    Usage: pyobfus src/ -o dist/ --preset ml")
 
     click.echo("\n  PRO PRESETS (Requires Pro license or trial)")
     click.echo("  " + "-" * 30)

--- a/pyobfus/config.py
+++ b/pyobfus/config.py
@@ -602,10 +602,16 @@ class ObfuscationConfig:
         """ML/model-serving preset: protects inference wrappers safely.
 
         - Based on preset_safe (docstrings preserved)
-        - preserve_param_names=True (serving frameworks and tensor adapters
-          frequently call wrappers by keyword; this already covers parameter
-          names like `inputs`/`device`/`batch_size` — they don't also need to
-          be in exclude_names)
+        - preserve_param_names=True, matching every other framework preset's
+          convention for serving frameworks/tensor adapters that call
+          wrappers by keyword. NOTE: as of this writing, preserve_param_names
+          does not actually preserve parameter identifiers end-to-end through
+          the CLI for ANY preset that sets it (tracked in issue #25,
+          reproduced against --preset fastapi too — it is a pre-existing,
+          cross-preset gap, not specific to this preset). Once #25 is fixed
+          this flag will start doing what its name says; left set here for
+          forward-compatibility and consistency with the other presets, not
+          because it currently delivers on that promise.
         - exclude_names covers only method names external code dispatches by
           exact string (sklearn's `predict`/`fit`/`transform`, PyTorch's
           `forward` via `nn.Module.__call__`, HuggingFace's `generate`/

--- a/pyobfus/config.py
+++ b/pyobfus/config.py
@@ -598,6 +598,51 @@ class ObfuscationConfig:
         return config
 
     @classmethod
+    def preset_ml(cls) -> "ObfuscationConfig":
+        """ML/model-serving preset: protects inference wrappers safely.
+
+        - Based on preset_safe (docstrings preserved)
+        - preserve_param_names=True (serving frameworks and tensor adapters
+          frequently call wrappers by keyword; this already covers parameter
+          names like `inputs`/`device`/`batch_size` — they don't also need to
+          be in exclude_names)
+        - exclude_names covers only method names external code dispatches by
+          exact string (sklearn's `predict`/`fit`/`transform`, PyTorch's
+          `forward` via `nn.Module.__call__`, HuggingFace's `generate`/
+          tokenizer `encode`) — generic variable-name words like `model` or
+          `pipeline` are deliberately NOT blanket-excluded here, since
+          exclude_names matches that exact identifier anywhere in the whole
+          codebase, not just inside a wrapper's parameter list, and doing so
+          would leave unrelated business logic needlessly readable too
+        - Excludes model artifact directories that should not be rewritten
+
+        Runtime String Vault routing for model paths remains an opt-in Pro
+        source marker (`vault_secrets({...})`); preflight surfaces guidance for
+        unsafe model deserialization and artifact literals.
+        """
+        config = cls.preset_safe()
+        config.preserve_param_names = True
+        config.exclude_names = config.exclude_names | {
+            "predict",
+            "predict_proba",
+            "fit",
+            "transform",
+            "forward",
+            "generate",
+            "encode",
+        }
+        config.exclude_patterns = list(config.exclude_patterns) + [
+            "**/models/**",
+            "**/checkpoints/**",
+            "**/weights/**",
+            "**/*.pt",
+            "**/*.pth",
+            "**/*.onnx",
+            "**/*.safetensors",
+        ]
+        return config
+
+    @classmethod
     def get_preset(cls, name: str) -> "ObfuscationConfig":
         """
         Get a preset configuration by name.
@@ -605,7 +650,7 @@ class ObfuscationConfig:
         Args:
             name: Preset name. Available:
                 - Community: safe, balanced, aggressive
-                - Framework: fastapi, django, flask, pydantic, click, sqlalchemy
+                - Framework: fastapi, django, flask, pydantic, click, sqlalchemy, ml
                 - Pro: trial, commercial, library, maximum
 
         Returns:
@@ -626,6 +671,7 @@ class ObfuscationConfig:
             "pydantic": cls.preset_pydantic,
             "click": cls.preset_click,
             "sqlalchemy": cls.preset_sqlalchemy,
+            "ml": cls.preset_ml,
             # Pro
             "trial": cls.preset_trial,
             "commercial": cls.preset_commercial,
@@ -660,6 +706,7 @@ class ObfuscationConfig:
             "pydantic",
             "click",
             "sqlalchemy",
+            "ml",
             # Pro
             "trial",
             "commercial",
@@ -668,7 +715,9 @@ class ObfuscationConfig:
         ]
 
     # Framework presets are community-tier (no Pro license required)
-    FRAMEWORK_PRESETS = frozenset({"fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"})
+    FRAMEWORK_PRESETS = frozenset(
+        {"fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"}
+    )
 
     def add_exclude_pattern(self, pattern: str) -> None:
         """Add a file pattern to exclude."""

--- a/pyobfus/core/preflight.py
+++ b/pyobfus/core/preflight.py
@@ -40,6 +40,8 @@ CAT_NAME_STRING = "name_string_reference"
 CAT_ALL_EXPORT = "all_export"
 CAT_FRAMEWORK = "framework_reflection"
 CAT_ENTRY_POINT = "entry_point"
+CAT_UNSAFE_DESERIALIZATION = "unsafe_deserialization"
+CAT_MODEL_ARTIFACT_LITERAL = "model_artifact_literal"
 
 
 @dataclass
@@ -80,6 +82,13 @@ class PreflightReport:
     suggested_preset: Optional[str] = None
     suggested_excludes: List[str] = field(default_factory=list)
     ai_hint: str = ""
+    # Internal bookkeeping only -- not part of the public to_dict() contract.
+    # Several _FRAMEWORK_SIGNATURES entries can share one display name (e.g.
+    # torch/tensorflow/keras/transformers/sklearn/joblib all map to "ml"), so
+    # `frameworks` dedupes by display name and loses which specific module(s)
+    # actually triggered detection. Track the raw signature keys here so
+    # _finalize can recover the correct per-module exclude glob(s).
+    _preset_signature_keys: Dict[str, Set[str]] = field(default_factory=dict, repr=False)
 
     # ---- summaries ---------------------------------------------------
 
@@ -144,7 +153,27 @@ _FRAMEWORK_SIGNATURES: Dict[str, Tuple[str, str, str]] = {
     "pydantic": ("Pydantic", "pydantic", "**/models/**"),
     "click": ("Click CLI", "click", ""),
     "sqlalchemy": ("SQLAlchemy", "sqlalchemy", "**/models/**"),
+    "torch": ("ML/model-serving", "ml", "**/checkpoints/**"),
+    "tensorflow": ("ML/model-serving", "ml", "**/models/**"),
+    "keras": ("ML/model-serving", "ml", "**/models/**"),
+    "transformers": ("ML/model-serving", "ml", "**/models/**"),
+    "sklearn": ("ML/model-serving", "ml", "**/models/**"),
+    "joblib": ("ML/model-serving", "ml", "**/models/**"),
 }
+
+_MODEL_ARTIFACT_SUFFIXES = (
+    ".pt",
+    ".pth",
+    ".pkl",
+    ".pickle",
+    ".joblib",
+    ".onnx",
+    ".safetensors",
+    ".h5",
+    ".keras",
+    ".ckpt",
+    ".bin",
+)
 
 
 class _RiskVisitor(ast.NodeVisitor):
@@ -258,6 +287,12 @@ class _RiskVisitor(ast.NodeVisitor):
                 f"{name}() — runtime introspection exposes obfuscated names.",
                 "Review output carefully; obfuscated names will leak through.",
             )
+        elif name == "load" and self._imported("pickle"):
+            self._add_unsafe_deserialization(node, "pickle.load()")
+        elif name == "loads" and self._imported("pickle"):
+            self._add_unsafe_deserialization(node, "pickle.loads()")
+        elif name == "load" and self._imported("joblib"):
+            self._add_unsafe_deserialization(node, "joblib.load()")
 
     def _check_attr_call(self, func: ast.Attribute, node: ast.Call) -> None:
         # importlib.import_module, importlib.__import__
@@ -279,6 +314,32 @@ class _RiskVisitor(ast.NodeVisitor):
                 f"inspect.{func.attr}() — runtime reflection.",
                 "Review if the reflected names need preservation.",
             )
+        if isinstance(func.value, ast.Name):
+            owner = func.value.id
+            if owner == "pickle" and func.attr in {"load", "loads"}:
+                self._add_unsafe_deserialization(node, f"pickle.{func.attr}()")
+            elif owner == "joblib" and func.attr == "load":
+                self._add_unsafe_deserialization(node, "joblib.load()")
+            elif (
+                owner == "torch"
+                and func.attr == "load"
+                and not _has_true_keyword(node, "weights_only")
+            ):
+                self._add_unsafe_deserialization(node, "torch.load() without weights_only=True")
+            elif owner in {"tensorflow", "keras"} and func.attr == "load_model":
+                self._add_unsafe_deserialization(node, f"{owner}.load_model()")
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str) and _looks_like_model_artifact(node.value):
+            self._add(
+                CAT_MODEL_ARTIFACT_LITERAL,
+                SEVERITY_LOW,
+                node,
+                "Model artifact path literal detected.",
+                "For Pro builds, wrap model/weight paths with vault_secrets({...}) "
+                "and enable --vault so paths route through the Runtime String Vault.",
+            )
+        self.generic_visit(node)
 
     # ---- name-string references ----------------------------------------
 
@@ -313,6 +374,19 @@ class _RiskVisitor(ast.NodeVisitor):
             )
         )
 
+    def _add_unsafe_deserialization(self, node: ast.Call, call_name: str) -> None:
+        self._add(
+            CAT_UNSAFE_DESERIALIZATION,
+            SEVERITY_HIGH,
+            node,
+            f"{call_name} can execute code when loading untrusted model artifacts.",
+            "Prefer safetensors or ONNX where possible; for torch.load use "
+            "weights_only=True and validate artifact provenance before loading.",
+        )
+
+    def _imported(self, module: str) -> bool:
+        return module in self.imports
+
 
 def _is_main_guard(test: ast.expr) -> bool:
     """Detect `__name__ == "__main__"` in any argument order."""
@@ -340,6 +414,20 @@ def _first_arg_is_constant_string(node: ast.Call) -> bool:
         return False
     arg = node.args[1]
     return isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+
+
+def _has_true_keyword(node: ast.Call, keyword_name: str) -> bool:
+    for kw in node.keywords:
+        if kw.arg == keyword_name and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+            return True
+    return False
+
+
+def _looks_like_model_artifact(value: str) -> bool:
+    lowered = value.lower()
+    return lowered.endswith(_MODEL_ARTIFACT_SUFFIXES) or any(
+        part in lowered for part in ("/models/", "/checkpoints/", "\\models\\", "\\checkpoints\\")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -392,10 +480,12 @@ class PreflightChecker:
 
         # Fold framework detection into the aggregate report.
         for mod in visitor.imports:
-            sig = _FRAMEWORK_SIGNATURES.get(mod.lower())
+            mod_key = mod.lower()
+            sig = _FRAMEWORK_SIGNATURES.get(mod_key)
             if not sig:
                 continue
-            name, _preset, _exclude = sig
+            name, preset, _exclude = sig
+            report._preset_signature_keys.setdefault(preset, set()).add(mod_key)
             existing = next((f for f in report.frameworks if f.name == name), None)
             if existing:
                 if str(file_path) not in existing.files:
@@ -409,15 +499,34 @@ class PreflightChecker:
 
     def _finalize(self, report: PreflightReport) -> None:
         # Framework-driven preset suggestion (first detected wins, highest priority first)
-        priority = ["fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"]
+        priority = ["fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"]
         # Map framework display name -> preset key via _FRAMEWORK_SIGNATURES
-        # ("FastAPI" -> "fastapi", "Click CLI" -> "click", ...)
+        # ("FastAPI" -> "fastapi", "Click CLI" -> "click", ...). Several
+        # signature entries can share one display name (all six ML libraries
+        # map to "ML/model-serving"), so `frameworks` (deduped by display
+        # name) only tells us the preset, not which module(s) actually
+        # triggered it — read that back from report._preset_signature_keys
+        # (populated per-module during scanning) instead of matching the
+        # first _FRAMEWORK_SIGNATURES entry with the same display name, which
+        # would always resolve to whichever entry happens to be inserted
+        # first regardless of what was really imported.
         framework_keys: Dict[str, FrameworkHit] = {}
+        framework_excludes: Dict[str, List[str]] = {}
         for fw in report.frameworks:
-            for key, (name, _p, _e) in _FRAMEWORK_SIGNATURES.items():
+            for name, preset, _e in _FRAMEWORK_SIGNATURES.values():
                 if fw.name == name:
-                    framework_keys[key] = fw
+                    framework_keys[preset] = fw
                     break
+        for preset, mod_keys in report._preset_signature_keys.items():
+            globs = sorted(
+                {
+                    _FRAMEWORK_SIGNATURES[mod_key][2]
+                    for mod_key in mod_keys
+                    if _FRAMEWORK_SIGNATURES[mod_key][2]
+                }
+            )
+            if globs:
+                framework_excludes[preset] = globs
 
         for key in priority:
             if key in framework_keys:
@@ -427,10 +536,10 @@ class PreflightChecker:
         # Suggested excludes based on detected frameworks
         seen_excludes: Set[str] = set()
         for key in framework_keys:
-            _name, _preset, exclude_glob = _FRAMEWORK_SIGNATURES[key]
-            if exclude_glob and exclude_glob not in seen_excludes:
-                report.suggested_excludes.append(exclude_glob)
-                seen_excludes.add(exclude_glob)
+            for exclude_glob in framework_excludes.get(key, []):
+                if exclude_glob not in seen_excludes:
+                    report.suggested_excludes.append(exclude_glob)
+                    seen_excludes.add(exclude_glob)
 
         # AI hint: the single next command the user (or an AI agent) should run.
         counts = report.severity_counts()
@@ -451,8 +560,7 @@ class PreflightChecker:
             )
         elif report.suggested_preset:
             report.ai_hint = (
-                f"Low risk. Run: "
-                f"pyobfus {report.root} -o dist/ --preset {report.suggested_preset}"
+                f"Low risk. Run: pyobfus {report.root} -o dist/ --preset {report.suggested_preset}"
             )
         else:
             report.ai_hint = f"Low risk. Run: pyobfus {report.root} -o dist/ --preset balanced"

--- a/pyobfus_mcp/pyobfus_mcp/server.py
+++ b/pyobfus_mcp/pyobfus_mcp/server.py
@@ -115,9 +115,9 @@ def _build_server() -> Any:
         name="check_obfuscation_risks",
         description=(
             "Scan a Python project for patterns that may break obfuscation "
-            "(eval/exec, dynamic attribute access, framework reflection). "
+            "(eval/exec, dynamic attribute access, framework reflection, unsafe model loading). "
             "Returns severity counts, detected frameworks (FastAPI/Django/"
-            "Flask/Pydantic/Click/SQLAlchemy), and a suggested preset."
+            "Flask/Pydantic/Click/SQLAlchemy/ML), and a suggested preset."
         ),
         meta=dict(_META_COMMUNITY),
     )

--- a/pyobfus_mcp/pyobfus_mcp/tools.py
+++ b/pyobfus_mcp/pyobfus_mcp/tools.py
@@ -478,7 +478,7 @@ def list_presets() -> Dict[str, Any]:
         "ai_hint": (
             "Framework presets are free and the recommended starting point "
             "when your project imports fastapi/django/flask/pydantic/click/"
-            "sqlalchemy. Fall back to 'balanced' otherwise."
+            "sqlalchemy or ML/model-serving libraries. Fall back to 'balanced' otherwise."
         ),
         "next_tool": _next_tool("explain_preset", "inspect a specific preset before applying it"),
     }

--- a/pyobfus_mcp/tests/test_tools.py
+++ b/pyobfus_mcp/tests/test_tools.py
@@ -207,7 +207,7 @@ def test_list_presets_groups_correctly() -> None:
     for p in ("safe", "balanced", "aggressive"):
         assert p in result["community"]
     # Framework
-    for p in ("fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"):
+    for p in ("fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"):
         assert p in result["framework"]
     # Pro
     for p in ("trial", "commercial", "library", "maximum"):
@@ -296,13 +296,13 @@ def test_build_server_attaches_meta_to_each_tool() -> None:
         # mcp SDK exposes the meta dict via `.meta` on the Tool object.
         meta = getattr(tool, "meta", None)
         assert meta is not None, f"{tool.name} has no meta dict"
-        assert (
-            meta.get("version") == "1"
-        ), f"{tool.name} meta.version={meta.get('version')!r}, expected '1'"
+        assert meta.get("version") == "1", (
+            f"{tool.name} meta.version={meta.get('version')!r}, expected '1'"
+        )
         expected_tier = "pro_funnel" if tool.name in expected_pro_funnel else "community"
-        assert (
-            meta.get("tier") == expected_tier
-        ), f"{tool.name} meta.tier={meta.get('tier')!r}, expected {expected_tier!r}"
+        assert meta.get("tier") == expected_tier, (
+            f"{tool.name} meta.tier={meta.get('tier')!r}, expected {expected_tier!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -326,9 +326,9 @@ def test_check_obfuscation_risks_no_pro_value_on_clean_project(tmp_path: Path) -
     _write(tmp_path, "a.py", "def greet(name): return f'hi {name}'\n")
     result = check_obfuscation_risks(str(tmp_path))
     assert result["status"] == "success"
-    assert (
-        "pro_value" not in result
-    ), f"clean project should not get pro_value; got {result.get('pro_value')!r}"
+    assert "pro_value" not in result, (
+        f"clean project should not get pro_value; got {result.get('pro_value')!r}"
+    )
 
 
 def test_check_obfuscation_risks_pro_value_on_sensitive_literals(

--- a/tests/test_framework_presets.py
+++ b/tests/test_framework_presets.py
@@ -15,7 +15,7 @@ from pyobfus.config import ObfuscationConfig
 
 @pytest.mark.parametrize(
     "preset_name",
-    ["fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"],
+    ["fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"],
 )
 def test_framework_preset_is_registered(preset_name: str) -> None:
     cfg = ObfuscationConfig.get_preset(preset_name)
@@ -28,13 +28,13 @@ def test_framework_preset_is_registered(preset_name: str) -> None:
 
 def test_framework_presets_in_list_presets() -> None:
     presets = ObfuscationConfig.list_presets()
-    for fw in ["fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"]:
+    for fw in ["fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"]:
         assert fw in presets
 
 
 def test_framework_presets_registered_constant() -> None:
     assert ObfuscationConfig.FRAMEWORK_PRESETS == frozenset(
-        {"fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"}
+        {"fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"}
     )
 
 
@@ -140,6 +140,50 @@ def test_sqlalchemy_preset_excludes_orm_dunders_and_session() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ML/model-serving
+# ---------------------------------------------------------------------------
+
+
+def test_ml_preset_preserves_model_serving_surface() -> None:
+    cfg = ObfuscationConfig.preset_ml()
+    # Only names external code dispatches by exact string (sklearn/PyTorch/
+    # HuggingFace method conventions) are blanket-excluded.
+    for name in ("predict", "predict_proba", "fit", "transform", "forward", "generate", "encode"):
+        assert name in cfg.exclude_names
+    assert cfg.preserve_param_names is True
+    assert cfg.remove_docstrings is False
+
+
+def test_ml_preset_does_not_blanket_exclude_generic_variable_names() -> None:
+    # Regression guard: these are common variable/attribute names far beyond
+    # ML code. preserve_param_names=True already covers them as parameters;
+    # blanket-excluding them in exclude_names would leave unrelated business
+    # logic readable everywhere that word appears as an identifier.
+    cfg = ObfuscationConfig.preset_ml()
+    for name in (
+        "model",
+        "tokenizer",
+        "pipeline",
+        "device",
+        "dtype",
+        "batch_size",
+        "inputs",
+        "outputs",
+        "preprocess",
+        "postprocess",
+        "load_model",
+        "embed",
+    ):
+        assert name not in cfg.exclude_names
+
+
+def test_ml_preset_excludes_model_artifact_paths() -> None:
+    cfg = ObfuscationConfig.preset_ml()
+    for pattern in ("**/models/**", "**/checkpoints/**", "**/*.safetensors"):
+        assert pattern in cfg.exclude_patterns
+
+
+# ---------------------------------------------------------------------------
 # CLI integration
 # ---------------------------------------------------------------------------
 
@@ -186,9 +230,28 @@ def test_list_presets_shows_frameworks() -> None:
     result = CliRunner().invoke(main, ["--list-presets"])
     assert result.exit_code == 0
     out = result.output
-    for fw in ("fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"):
+    for fw in ("fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"):
         assert fw in out
     assert "FRAMEWORK-AWARE PRESETS" in out
+
+
+def test_cli_ml_preset_preserves_dispatch_method_name(tmp_path) -> None:
+    # NOTE: preserve_param_names=True does not currently preserve parameter
+    # identifiers end-to-end through the CLI (tracked separately -- see the
+    # project issue tracker; reproduced against --preset fastapi too, so it
+    # is a pre-existing, cross-preset gap, not specific to --preset ml).
+    # This test sticks to what actually works today: exclude_names keeps the
+    # framework-dispatched method name itself unmangled.
+    src = tmp_path / "serve.py"
+    src.write_text(
+        "def predict(inputs, batch_size=8):\n    return inputs[:batch_size]\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "out.py"
+    result = CliRunner().invoke(main, [str(src), "-o", str(out), "--preset", "ml"])
+    assert result.exit_code == 0, result.output
+    code = out.read_text(encoding="utf-8")
+    assert "def predict(" in code
 
 
 def test_unknown_preset_is_rejected() -> None:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -15,7 +15,9 @@ from pyobfus.core.preflight import (
     CAT_ENTRY_POINT,
     CAT_FRAMEWORK,  # noqa: F401  (imported for category registry completeness)
     CAT_INTROSPECTION,
+    CAT_MODEL_ARTIFACT_LITERAL,
     CAT_NAME_STRING,
+    CAT_UNSAFE_DESERIALIZATION,
     PreflightChecker,
     SEVERITY_HIGH,
     SEVERITY_MEDIUM,
@@ -187,6 +189,106 @@ def test_framework_priority_fastapi_over_pydantic(tmp_path: Path) -> None:
     )
     report = PreflightChecker().check_path(f)
     assert report.suggested_preset == "fastapi"
+
+
+def test_framework_ml_suggests_ml_preset(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "serve.py",
+        """
+        import torch
+        def predict(x):
+            return torch.load("weights/model.pt")
+        """,
+    )
+    report = PreflightChecker().check_path(f)
+    assert any(fw.name == "ML/model-serving" for fw in report.frameworks)
+    assert report.suggested_preset == "ml"
+    assert "**/checkpoints/**" in report.suggested_excludes
+
+
+def test_framework_sklearn_only_suggests_models_exclude_not_torch_checkpoints(
+    tmp_path: Path,
+) -> None:
+    # Regression guard: torch/tensorflow/keras/transformers/sklearn/joblib all
+    # share the "ML/model-serving" display name, so a project that imports
+    # ONLY sklearn (no torch at all) must still get sklearn's own
+    # **/models/** suggestion, not torch's **/checkpoints/** by coincidence of
+    # dict-iteration order.
+    f = _write(
+        tmp_path,
+        "serve.py",
+        """
+        import sklearn
+        def predict(x):
+            return x
+        """,
+    )
+    report = PreflightChecker().check_path(f)
+    assert any(fw.name == "ML/model-serving" for fw in report.frameworks)
+    assert report.suggested_preset == "ml"
+    assert "**/models/**" in report.suggested_excludes
+    assert "**/checkpoints/**" not in report.suggested_excludes
+
+
+def test_framework_torch_and_sklearn_together_suggest_both_excludes(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "serve.py",
+        """
+        import torch
+        import sklearn
+        def predict(x):
+            return x
+        """,
+    )
+    report = PreflightChecker().check_path(f)
+    assert "**/checkpoints/**" in report.suggested_excludes
+    assert "**/models/**" in report.suggested_excludes
+
+
+# ---------------------------------------------------------------------------
+# ML/model-serving safety
+# ---------------------------------------------------------------------------
+
+
+def test_detects_pickle_load_as_unsafe_deserialization(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "model.py",
+        """
+        import pickle
+        with open("model.pkl", "rb") as fh:
+            model = pickle.load(fh)
+        """,
+    )
+    report = PreflightChecker().check_path(f)
+    assert any(r.category == CAT_UNSAFE_DESERIALIZATION for r in report.risks)
+    assert report.exit_code() == 1
+
+
+def test_detects_torch_load_without_weights_only(tmp_path: Path) -> None:
+    f = _write(
+        tmp_path,
+        "model.py",
+        """
+        import torch
+        model = torch.load("checkpoint.pth")
+        safe_weights = torch.load("weights.pth", weights_only=True)
+        """,
+    )
+    report = PreflightChecker().check_path(f)
+    risks = [r for r in report.risks if r.category == CAT_UNSAFE_DESERIALIZATION]
+    assert len(risks) == 1
+    assert "weights_only=True" in risks[0].message
+
+
+def test_detects_model_artifact_literal_with_vault_hint(tmp_path: Path) -> None:
+    f = _write(tmp_path, "model.py", 'MODEL_PATH = "models/classifier.safetensors"\n')
+    report = PreflightChecker().check_path(f)
+    risks = [r for r in report.risks if r.category == CAT_MODEL_ARTIFACT_LITERAL]
+    assert len(risks) == 1
+    assert "vault_secrets" in risks[0].suggestion
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -175,10 +175,10 @@ class TestListPresets:
         assert "balanced" in presets
         assert "aggressive" in presets
         # Framework-aware presets (added in v0.4.0 P0-3)
-        for fw in ("fastapi", "django", "flask", "pydantic", "click", "sqlalchemy"):
+        for fw in ("fastapi", "django", "flask", "pydantic", "click", "sqlalchemy", "ml"):
             assert fw in presets
-        # 3 community + 6 framework + 4 Pro = 13
-        assert len(presets) == 13
+        # 3 community + 7 framework + 4 Pro = 14
+        assert len(presets) == 14
 
 
 class TestPresetLimits:


### PR DESCRIPTION
Implements ROADMAP.md P2-19.

## What this adds

- **`--preset ml`** (community-tier): preserves the framework-dispatched
  method names external code actually calls by exact string
  (`predict`/`predict_proba`/`fit`/`transform` — sklearn; `forward` — PyTorch
  `nn.Module.__call__`; `generate`/`encode` — HuggingFace conventions), sets
  `preserve_param_names=True` for consistency with every other framework
  preset (see caveat below — this flag doesn't currently do anything),
  excludes model/checkpoint/weight artifact directories and common
  weight-file extensions.
- **`--check` guidance**: flags `pickle.load`/`pickle.loads`/`joblib.load`
  and `torch.load(...)` without `weights_only=True` as high-severity unsafe
  deserialization, and flags model/weight-artifact path literals with a
  suggestion to route them through the Pro Runtime String Vault
  (`vault_secrets({...})`).
- Framework auto-detection (`torch`/`tensorflow`/`keras`/`transformers`/
  `sklearn`/`joblib`) feeds the existing preset-suggestion flow in
  `pyobfus --check`.

## Process note

Initial implementation by Codex CLI (its environment lacks `black`/`mypy`,
so it couldn't run the full local gate). Reviewed and finished by Claude
Code:

- **Narrowed `exclude_names`**: the original preset blanket-excluded generic
  variable-name words (`model`, `device`, `dtype`, `inputs`, `outputs`,
  `pipeline`, `tokenizer`, `batch_size`, `preprocess`, `postprocess`,
  `load_model`) in addition to the genuinely framework-required method
  names. `exclude_names` matches an identifier anywhere in the whole
  codebase, not just inside a wrapper, and `preserve_param_names=True`
  (already set on this preset) already covers those words as *parameters* —
  so the broader list mostly just left unrelated business logic needlessly
  readable wherever those common words happened to appear. Narrowed to the
  method names with a real external-dispatch justification.
- **Fixed a dead-branch bug**: `torch`/`tensorflow`/`keras`/`transformers`/
  `sklearn`/`joblib` all share the "ML/model-serving" display name for
  dedup purposes, so the per-library suggested-exclude-glob logic always
  resolved to torch's `**/checkpoints/**` regardless of which library was
  actually detected — the other five libraries' `**/models/**` suggestion
  was unreachable. Now tracks the specific triggering module(s) and unions
  their globs correctly. Added a sklearn-only test and a torch+sklearn test
  to lock this in.
- Ran the full three-root test suite + `black`/`ruff`/`mypy` locally (all
  green — see CI).

## Found but NOT fixed here (filed as #25)

While testing this preset's parameter-name preservation claim, found that
`preserve_param_names=True` does not actually preserve parameter
identifiers end-to-end through the CLI — reproduced identically against
`--preset fastapi` (pre-existing, unrelated to this PR). The existing
fastapi test for this claim was a false positive (its assertion matched a
string dict key, not the actual renamed variable). This PR's own preset_ml
parameter-name test was rewritten to assert only on what currently works
(the dispatch method name staying unmangled via `exclude_names`), not the
broken parameter-name claim, and the bigger issue is filed separately since
it affects every framework preset, not just this one.

## Test plan

- [x] `pytest tests/` — 1057 passed, 1 skipped
- [x] `pytest pyobfus_mcp/tests/` — 73 passed
- [x] `pytest integration_tests/` — 7 passed
- [x] `black --check` / `ruff check` / `mypy` — all clean
- [x] New regression tests: exclude_names narrowness, sklearn-only exclude
      glob, torch+sklearn-together exclude glob union

Closes part of the P2-19 roadmap item (`docs/ROADMAP.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
