### PR TITLE
feat: --provenance-manifest local build-provenance JSON (P2-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--provenance-manifest PATH`** — writes a local JSON provenance manifest
+  for obfuscation runs: obfuscated files, effective config hash, pyobfus
+  version, mapping digest when `--save-mapping` is used, and a canonical
+  SHA-256 integrity digest (self-consistency check, not a cryptographic
+  signature — real signing via sigstore is future work). No new dependency
+  or phone-home service is required.
+
 ## [0.5.4] - 2026-07-19
 
 **Feature + honesty release.** Closes the last device-binding scope boundary

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ See [`skills/`](skills/) for the skill and install details. (This is distinct fr
 - **`pyobfus --init src/`** — zero-config onboarding: scans the project, detects FastAPI/Django/Pydantic/Click/SQLAlchemy, and writes a ready-to-use `pyobfus.yaml`.
 - **`pyobfus --unmap --trace error.log --mapping mapping.json`** — reverse obfuscated identifiers in a production stack trace so you can debug (or hand the trace to an AI assistant) without reversing the obfuscation itself.
 - **`pyobfus … --save-mapping mapping.json --trace-marker`** — stamp each obfuscated file with a `# pyobfus:obfuscated` header (id + mapping filename + the exact `--unmap` command) so an AI agent that lands in an obfuscated file from a traceback immediately knows it's pyobfus output and how to reverse the names.
+- **`pyobfus … --provenance-manifest provenance.json`** — write a local JSON manifest (obfuscated files, config hash, pyobfus version, mapping digest, and a self-consistency integrity digest — not a cryptographic signature) for offline build provenance.
 - **Framework-aware presets** — `--preset fastapi | django | flask | pydantic | click | sqlalchemy` with built-in exclusions for dispatch methods, decorators, ORM fields, migrations, and dependency-injection parameters.
 - **Global `--json`** — every CLI mode (`obfuscate`, `--check`, `--unmap`, `--init`) emits the same structured schema with an `ai_hint` field, ready for Claude Code, Cursor, Windsurf, and MCP servers to consume.
 

--- a/pyobfus/cli.py
+++ b/pyobfus/cli.py
@@ -293,6 +293,13 @@ except ImportError:
     "Use with `pyobfus --unmap` to reverse obfuscated stack traces.",
 )
 @click.option(
+    "--provenance-manifest",
+    "provenance_manifest_path",
+    type=click.Path(),
+    help="Write a local JSON provenance manifest (with an integrity digest, "
+    "not a cryptographic signature) for this obfuscation run.",
+)
+@click.option(
     "--trace-marker/--no-trace-marker",
     "trace_marker",
     default=False,
@@ -378,6 +385,7 @@ def main(
     check_mode: bool,
     json_output: bool,
     save_mapping_path: Optional[str],
+    provenance_manifest_path: Optional[str],
     trace_marker: bool,
     unmap_mode: bool,
     trace_path: Optional[str],
@@ -794,6 +802,7 @@ def main(
                         dry_run=dry_run,
                         stats=obfuscation_stats,
                         mapping_path=save_mapping_path,
+                        provenance_manifest_path=None,
                     )
                     return
                 # Fall through to normal text success path below by
@@ -875,6 +884,39 @@ def main(
                     err=True,
                 )
 
+        written_manifest_path: Optional[str] = None
+        if provenance_manifest_path and not dry_run:
+            from pyobfus.core.provenance import (
+                build_provenance_manifest,
+                save_provenance_manifest,
+            )
+
+            if input_path_obj.is_file():
+                manifest_files = [input_path_obj]
+                manifest_mode = "single_file"
+            else:
+                manifest_files = filter_python_files(input_path_obj, config.exclude_patterns)
+                manifest_mode = "cross_file" if cross_file else "directory"
+            manifest = build_provenance_manifest(
+                input_root=input_path_obj,
+                output_root=output_path_obj,
+                config=config,
+                files=manifest_files,
+                mapping_path=save_mapping_path,
+                preset=preset.lower() if preset else None,
+                mode=manifest_mode,
+            )
+            save_provenance_manifest(manifest, provenance_manifest_path)
+            written_manifest_path = provenance_manifest_path
+            if verbose:
+                click.echo(f"  Wrote provenance manifest: {provenance_manifest_path}")
+        elif provenance_manifest_path and dry_run:
+            if not json_output:
+                click.echo(
+                    "Warning: --provenance-manifest is skipped in --dry-run mode.",
+                    err=True,
+                )
+
         if json_output:
             sys.stdout = _saved_stdout
             _emit_obfuscate_success_json(
@@ -885,6 +927,7 @@ def main(
                 dry_run=dry_run,
                 stats=obfuscation_stats,
                 mapping_path=save_mapping_path,
+                provenance_manifest_path=written_manifest_path,
                 trace_marker_id=trace_marker_id,
             )
             return
@@ -1708,6 +1751,7 @@ def _emit_obfuscate_success_json(
     dry_run: bool,
     stats: Dict[str, int],
     mapping_path: Optional[str],
+    provenance_manifest_path: Optional[str] = None,
     trace_marker_id: Optional[str] = None,
 ) -> None:
     """Emit the obfuscation success summary as JSON."""
@@ -1716,6 +1760,10 @@ def _emit_obfuscate_success_json(
         ai_hint = (
             f"Obfuscation complete. To reverse a production traceback: "
             f"pyobfus --unmap --trace error.log --mapping {mapping_path}"
+        )
+    elif provenance_manifest_path:
+        ai_hint = (
+            f"Obfuscation complete. Provenance manifest written to {provenance_manifest_path}."
         )
     elif dry_run:
         ai_hint = "Dry run complete — no files written. Remove --dry-run to persist output."
@@ -1735,6 +1783,7 @@ def _emit_obfuscate_success_json(
         "dry_run": dry_run,
         "stats": stats,
         "mapping": mapping_path,
+        "provenance_manifest": provenance_manifest_path,
         "trace_marker_id": trace_marker_id,
         "ai_hint": ai_hint,
     }

--- a/pyobfus/core/provenance.py
+++ b/pyobfus/core/provenance.py
@@ -1,0 +1,155 @@
+"""Build provenance manifest for obfuscation runs.
+
+The manifest is intentionally local and offline-verifiable. It records the
+inputs/outputs, effective configuration hash, pyobfus version, and the digest
+of a mapping.json when one was produced. A canonical SHA-256 integrity digest
+covers the manifest payload without requiring a network service or new
+dependency.
+
+This digest is NOT a cryptographic signature: it only proves the manifest is
+internally self-consistent (the payload matches its own recorded digest). It
+does not prove who produced the manifest or stop someone who can edit the
+manifest file from recomputing a matching digest after tampering with it.
+Real signing (e.g. sigstore) is future work; see docs/ROADMAP.md P2-17.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+from pyobfus import __version__ as PYOBFUS_VERSION
+from pyobfus.config import ObfuscationConfig
+
+PROVENANCE_FORMAT_VERSION = 1
+
+
+def sha256_file(path: Union[str, Path]) -> Optional[str]:
+    """Return the SHA-256 hex digest of a file, or None when it is absent."""
+    p = Path(path)
+    if not p.exists() or not p.is_file():
+        return None
+    digest = hashlib.sha256()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def config_hash(config: ObfuscationConfig) -> str:
+    """Hash the effective obfuscation config with stable JSON normalization."""
+    payload = _normalize(config)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def build_provenance_manifest(
+    *,
+    input_root: Path,
+    output_root: Path,
+    config: ObfuscationConfig,
+    files: Iterable[Path],
+    mapping_path: Optional[Union[str, Path]],
+    preset: Optional[str],
+    mode: str,
+) -> Dict[str, Any]:
+    """Build a v1 provenance manifest payload with a local integrity digest."""
+    file_records: List[Dict[str, str]] = []
+    for input_file in sorted(files):
+        try:
+            rel = input_file.relative_to(input_root if input_root.is_dir() else input_root.parent)
+        except ValueError:
+            rel = Path(input_file.name)
+        output_file = (
+            output_root / rel if output_root.is_dir() or input_root.is_dir() else output_root
+        )
+        record: Dict[str, str] = {
+            "input": str(input_file),
+            "output": str(output_file),
+            "relative_path": rel.as_posix(),
+        }
+        output_digest = sha256_file(output_file)
+        if output_digest:
+            record["output_sha256"] = output_digest
+        file_records.append(record)
+
+    mapping_digest = sha256_file(mapping_path) if mapping_path else None
+    payload: Dict[str, Any] = {
+        "version": PROVENANCE_FORMAT_VERSION,
+        "pyobfus_version": PYOBFUS_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "tool": {"name": "pyobfus", "version": PYOBFUS_VERSION},
+        "input_root": str(input_root),
+        "output_root": str(output_root),
+        "mode": mode,
+        "preset": preset,
+        "config_hash": config_hash(config),
+        "mapping": {
+            "path": str(mapping_path) if mapping_path else None,
+            "sha256": mapping_digest,
+        },
+        "files": file_records,
+    }
+    payload["integrity"] = _integrity_digest_for(payload)
+    return payload
+
+
+def save_provenance_manifest(manifest: Dict[str, Any], path: Union[str, Path]) -> None:
+    """Write a provenance manifest to disk."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def verify_manifest_integrity(manifest: Dict[str, Any]) -> bool:
+    """Check the manifest's payload matches its own recorded integrity digest.
+
+    This detects accidental corruption (a byte flipped in transit, a partial
+    write) — it is NOT tamper detection. Anyone who can edit the manifest
+    file can recompute a matching digest after changing the payload, since
+    there is no private key involved. Do not describe a `True` result as
+    "verified" or "signed" in user-facing text.
+    """
+    integrity = manifest.get("integrity")
+    if not isinstance(integrity, dict):
+        return False
+    expected = _integrity_digest_for({k: v for k, v in manifest.items() if k != "integrity"})
+    return integrity == expected
+
+
+def _integrity_digest_for(payload: Dict[str, Any]) -> Dict[str, str]:
+    canonical = dict(payload)
+    canonical.pop("integrity", None)
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return {
+        "type": "sha256-canonical-json",
+        "digest": digest,
+        "note": (
+            "Self-consistency digest, not a cryptographic signature. Detects "
+            "accidental corruption; does not prove authenticity or resist "
+            "deliberate tampering by anyone who can edit this file."
+        ),
+    }
+
+
+def _normalize(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return _normalize(asdict(value))
+    if isinstance(value, dict):
+        return {
+            str(k): _normalize(v) for k, v in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_normalize(v) for v in value)
+    if isinstance(value, Path):
+        return str(value)
+    return value

--- a/tests/test_provenance_manifest.py
+++ b/tests/test_provenance_manifest.py
@@ -1,0 +1,134 @@
+"""Tests for the obfuscation provenance manifest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from pyobfus.cli import main
+from pyobfus.config import ObfuscationConfig
+from pyobfus.core.provenance import config_hash, verify_manifest_integrity
+
+
+def test_config_hash_is_stable_for_equivalent_sets() -> None:
+    a = ObfuscationConfig.preset_safe()
+    b = ObfuscationConfig.preset_safe()
+    b.exclude_names = set(reversed(sorted(b.exclude_names)))
+    assert config_hash(a) == config_hash(b)
+
+
+def test_cli_writes_provenance_manifest_with_mapping_digest(tmp_path: Path) -> None:
+    src = tmp_path / "app.py"
+    src.write_text("def predict(x):\n    return x + 1\n", encoding="utf-8")
+    out = tmp_path / "out.py"
+    mapping = tmp_path / "mapping.json"
+    manifest_path = tmp_path / "provenance.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            str(src),
+            "-o",
+            str(out),
+            "--preset",
+            "safe",
+            "--save-mapping",
+            str(mapping),
+            "--provenance-manifest",
+            str(manifest_path),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert manifest_path.exists()
+
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    assert data["tool"]["name"] == "pyobfus"
+    assert data["preset"] == "safe"
+    assert data["mapping"]["path"] == str(mapping)
+    assert data["mapping"]["sha256"]
+    assert data["files"][0]["input"] == str(src)
+    assert data["files"][0]["output"] == str(out)
+    assert data["files"][0]["output_sha256"]
+    assert verify_manifest_integrity(data)
+
+    payload = json.loads(result.output)
+    assert payload["provenance_manifest"] == str(manifest_path)
+
+
+def test_cli_writes_provenance_manifest_for_directory_input(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (src_dir / "b.py").write_text("def g():\n    return 2\n", encoding="utf-8")
+    out_dir = tmp_path / "dist"
+    manifest_path = tmp_path / "provenance.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            str(src_dir),
+            "-o",
+            str(out_dir),
+            "--provenance-manifest",
+            str(manifest_path),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert len(data["files"]) == 2
+    relative_paths = {f["relative_path"] for f in data["files"]}
+    assert relative_paths == {"a.py", "b.py"}
+    for f in data["files"]:
+        assert Path(f["output"]).exists()
+        assert f["output_sha256"]
+    assert verify_manifest_integrity(data)
+
+
+def test_verify_manifest_integrity_detects_tampering(tmp_path: Path) -> None:
+    src = tmp_path / "app.py"
+    src.write_text("def predict(x):\n    return x + 1\n", encoding="utf-8")
+    out = tmp_path / "out.py"
+    manifest_path = tmp_path / "provenance.json"
+
+    CliRunner().invoke(
+        main,
+        [str(src), "-o", str(out), "--provenance-manifest", str(manifest_path), "--json"],
+    )
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert verify_manifest_integrity(data)
+
+    # Tamper with the payload without recomputing the digest: this is what
+    # verify_manifest_integrity is actually able to catch (accidental
+    # corruption / a stale digest) -- see its docstring for what it does
+    # NOT catch (a deliberate tamperer who recomputes the digest too).
+    tampered = dict(data)
+    tampered["files"] = []
+    assert not verify_manifest_integrity(tampered)
+
+
+def test_dry_run_does_not_write_provenance_manifest(tmp_path: Path) -> None:
+    src = tmp_path / "app.py"
+    src.write_text("x = 1\n", encoding="utf-8")
+    manifest_path = tmp_path / "provenance.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            str(src),
+            "-o",
+            str(tmp_path / "out.py"),
+            "--dry-run",
+            "--provenance-manifest",
+            str(manifest_path),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert not manifest_path.exists()
+    payload = json.loads(result.output)
+    assert payload["provenance_manifest"] is None


### PR DESCRIPTION
Implements ROADMAP.md P2-17.

## What this adds

`--provenance-manifest PATH` writes a local, offline JSON manifest for an
obfuscation run: obfuscated files (input/output paths + output SHA-256),
the effective config hash, pyobfus version, and the `mapping.json` digest
when `--save-mapping` is also used. No new dependency, no network/phone-home
service. Skipped (with a warning) under `--dry-run`, since no output files
exist yet to hash.

## Process note

Initial implementation by Codex CLI (its environment lacks `black`/`mypy`,
so it couldn't run the full local gate). Reviewed and finished by Claude
Code:

- **Renamed "signature" → "integrity digest" throughout** (code, CLI help,
  README, CHANGELOG). What the mechanism actually does: a SHA-256 over the
  manifest's own canonical JSON payload. That proves the manifest is
  internally self-consistent — it does **not** prove who produced it, and
  it does **not** stop someone who can edit the manifest file from
  recomputing a matching digest after tampering with the payload, since
  there's no private key involved anywhere in this v0. Calling that a
  "signature" would have overclaimed what it protects against. Real signing
  (sigstore) stays future work, exactly as the original ROADMAP item says.
- **Fixed a real mypy error**: `asdict()` only accepts a dataclass
  *instance*, but `is_dataclass()`'s type guard also allows a bare
  class/type, which mypy correctly flagged as a type mismatch. Added an
  `isinstance` narrowing.
- **Fixed a real `black --check` failure** in an unrelated file Codex had
  touched by hand (its environment couldn't run `black` to verify).
- **Added test coverage** for the directory/multi-file input path (the more
  complex relative-path-resolution logic, previously only exercised for the
  single-file case) and a tamper-detection test that documents precisely
  what `verify_manifest_integrity` does and does not catch.
- **Decoupled this PR's tests from `--preset ml`** (P2-19, PR #26) — uses the
  pre-existing `safe` preset instead, so this PR is reviewable and mergeable
  independently in either order.

## Test plan

- [x] `pytest tests/` — 1051 passed, 1 skipped
- [x] `pytest pyobfus_mcp/tests/` — 73 passed
- [x] `pytest integration_tests/` — 7 passed
- [x] `black --check` / `ruff check` / `mypy` — all clean
- [x] New tests: directory-mode manifest, tamper-detection

Closes part of the P2-17 roadmap item (`docs/ROADMAP.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)